### PR TITLE
Options management support

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ fastify.get('/decode', async (request, reply) => {
     const decodedToken = fastify.jwt.decode(token)
 
     // We decode the token using completely overided the default options
-    const decodedTokenAlt = fastify.jwt.decode(token, { complete: false })
+    const decodedTokenAlt = fastify.jwt.decode(tokenAlt, { complete: false })
 
     return { decodedToken, decodedTokenAlt }
     /**

--- a/jwt.js
+++ b/jwt.js
@@ -160,6 +160,8 @@ function fastifyJwt (fastify, options, next) {
   }
 
   function requestVerify (options, next) {
+    const badRequestError = new BadRequest('Format is Authorization: Bearer [token]')
+
     if (typeof options === 'function' && !next) {
       next = options
       options = Object.assign({}, verifyOptions)
@@ -187,10 +189,10 @@ function fastifyJwt (fastify, options, next) {
         token = parts[1]
 
         if (!/^Bearer$/i.test(scheme)) {
-          return next(new BadRequest('Format is Authorization: Bearer [token]'))
+          return next(badRequestError)
         }
       } else {
-        return next(new BadRequest('Format is Authorization: Bearer [token]'))
+        return next(badRequestError)
       }
     } else {
       return next(new Unauthorized('No Authorization was found in request.headers'))

--- a/jwt.js
+++ b/jwt.js
@@ -20,7 +20,7 @@ function fastifyJwt (fastify, options, next) {
     return next(new Error('missing secret'))
   }
 
-  let secret = options.secret
+  const secret = options.secret
   let secretOrPrivateKey
   let secretOrPublicKey
 
@@ -39,19 +39,22 @@ function fastifyJwt (fastify, options, next) {
   if (typeof secretCallbackSign !== 'function') { secretCallbackSign = wrapStaticSecretInCallback(secretCallbackSign) }
   if (typeof secretCallbackVerify !== 'function') { secretCallbackVerify = wrapStaticSecretInCallback(secretCallbackVerify) }
 
-  let defaultOptions = options.options || {}
+  const decodeOptions = options.decode || {}
+  const signOptions = options.sign || {}
+  const verifyOptions = options.verify || {}
+
   if (
-    defaultOptions &&
-    defaultOptions.algorithm &&
-    defaultOptions.algorithm.includes('RS') &&
+    signOptions &&
+    signOptions.algorithm &&
+    signOptions.algorithm.includes('RS') &&
     typeof secret === 'string'
   ) {
     return next(new Error(`RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret`))
   }
   if (
-    defaultOptions &&
-    defaultOptions.algorithm &&
-    defaultOptions.algorithm.includes('ES') &&
+    signOptions &&
+    signOptions.algorithm &&
+    signOptions.algorithm.includes('ES') &&
     typeof secret === 'string'
   ) {
     return next(new Error(`ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret`))
@@ -59,72 +62,84 @@ function fastifyJwt (fastify, options, next) {
 
   fastify.decorate('jwt', {
     decode: decode,
+    options: {
+      decode: decodeOptions,
+      sign: signOptions,
+      verify: verifyOptions
+    },
+    secret: secret,
     sign: sign,
-    verify: verify,
-    secret: secret
+    verify: verify
   })
-
-  fastify.decorateReply('jwtSign', replySign)
-
   fastify.decorateRequest('jwtVerify', requestVerify)
+  fastify.decorateReply('jwtSign', replySign)
 
   next()
 
-  function sign (payload, signOptions, callback) {
-    assert(payload, 'missing payload')
-
-    signOptions = signOptions || {}
-    if (typeof signOptions === 'function') {
-      callback = signOptions
-      signOptions = {}
-    }
-    signOptions = Object.assign({}, defaultOptions)
-    delete signOptions['algorithms']
-
-    if (typeof callback === 'function') {
-      jwt.sign(payload, secretOrPrivateKey, signOptions, callback)
-    } else {
-      return jwt.sign(payload, secretOrPrivateKey, signOptions)
-    }
-  }
-
-  function verify (token, verifyOptions, callback) {
-    assert(token, 'missing token')
-    assert(secret, 'missing secret')
-
-    verifyOptions = verifyOptions || {}
-    if ((typeof verifyOptions === 'function') && !callback) {
-      callback = verifyOptions
-      verifyOptions = {}
-    }
-    verifyOptions = Object.assign({}, defaultOptions)
-
-    if (typeof callback === 'function') {
-      jwt.verify(token, secretOrPublicKey, verifyOptions, callback)
-    } else {
-      return jwt.verify(token, secretOrPublicKey, verifyOptions)
-    }
-  }
-
   function decode (token, options) {
     assert(token, 'missing token')
-    options = options || {}
+
+    if (!options) {
+      options = Object.assign({}, decodeOptions)
+    }
+
     return jwt.decode(token, options)
   }
 
-  function replySign (payload, signOptions, next) {
-    if (typeof signOptions === 'function') {
-      next = signOptions
-      signOptions = {}
-    } // support no options
-    signOptions = Object.assign({}, defaultOptions)
-    delete signOptions['algorithms']
+  function sign (payload, options, callback) {
+    assert(payload, 'missing payload')
 
-    let reply = this
+    if (typeof options === 'function') {
+      callback = options
+      options = Object.assign({}, signOptions)
+    }
+
+    if (!options) {
+      options = Object.assign({}, signOptions)
+    }
+
+    if (typeof callback === 'function') {
+      jwt.sign(payload, secretOrPrivateKey, options, callback)
+    } else {
+      return jwt.sign(payload, secretOrPrivateKey, options)
+    }
+  }
+
+  function verify (token, options, callback) {
+    assert(token, 'missing token')
+    assert(secretOrPublicKey, 'missing secret')
+
+    if ((typeof options === 'function') && !callback) {
+      callback = options
+      options = Object.assign({}, verifyOptions)
+    }
+
+    if (!options) {
+      options = Object.assign({}, verifyOptions)
+    }
+
+    if (typeof callback === 'function') {
+      jwt.verify(token, secretOrPublicKey, options, callback)
+    } else {
+      return jwt.verify(token, secretOrPublicKey, options)
+    }
+  }
+
+  function replySign (payload, options, next) {
+    if (typeof options === 'function') {
+      next = options
+      options = Object.assign({}, signOptions)
+    } // support no options
+
+    if (!options) {
+      options = Object.assign({}, signOptions)
+    }
+
+    const reply = this
 
     if (next === undefined) {
       return new Promise(function (resolve, reject) {
-        reply.jwtSign(payload, signOptions, function (err, val) {
+        reply.jwtSign(payload, options, function (err, val) {
           err ? reject(err) : resolve(val)
         })
       })
@@ -139,23 +154,26 @@ function fastifyJwt (fastify, options, next) {
         secretCallbackSign(reply.request, payload, callback)
       },
       function sign (secretOrPrivateKey, callback) {
-        jwt.sign(payload, secretOrPrivateKey, signOptions, callback)
+        jwt.sign(payload, secretOrPrivateKey, options, callback)
       }
     ], next)
   }
 
-  function requestVerify (verifyOptions, next) {
-    if (typeof verifyOptions === 'function') {
-      next = verifyOptions
-      verifyOptions = {}
+  function requestVerify (options, next) {
+    if (typeof options === 'function' && !next) {
+      next = options
+      options = Object.assign({}, verifyOptions)
     } // support no options
-    verifyOptions = Object.assign({}, defaultOptions)
 
-    let request = this
+    if (!options) {
+      options = Object.assign({}, verifyOptions)
+    }
+
+    const request = this
 
     if (next === undefined) {
       return new Promise(function (resolve, reject) {
-        request.jwtVerify(verifyOptions, function (err, val) {
+        request.jwtVerify(options, function (err, val) {
           err ? reject(err) : resolve(val)
         })
       })
@@ -176,14 +194,14 @@ function fastifyJwt (fastify, options, next) {
       return next(new Unauthorized('No Authorization was found in request.headers'))
     }
 
-    let decodedToken = jwt.decode(token, options)
+    let decodedToken = jwt.decode(token, decodeOptions)
 
     steed.waterfall([
       function getSecret (callback) {
         secretCallbackVerify(request, decodedToken, callback)
       },
       function verify (secretOrPublicKey, callback) {
-        jwt.verify(token, secretOrPublicKey, verifyOptions, callback)
+        jwt.verify(token, secretOrPublicKey, options, callback)
       }
     ], function (err, result) {
       if (err) next(err)

--- a/jwt.js
+++ b/jwt.js
@@ -9,6 +9,8 @@ const {
   Unauthorized
 } = require('http-errors')
 
+const badRequestErrorMessage = 'Format is Authorization: Bearer [token]'
+
 function wrapStaticSecretInCallback (secret) {
   return function (request, payload, cb) {
     return cb(null, secret)
@@ -18,6 +20,10 @@ function wrapStaticSecretInCallback (secret) {
 function fastifyJwt (fastify, options, next) {
   if (!options.secret) {
     return next(new Error('missing secret'))
+  }
+
+  if (options.options) {
+    return next(new Error('options prefix is deprecated'))
   }
 
   const secret = options.secret
@@ -160,8 +166,6 @@ function fastifyJwt (fastify, options, next) {
   }
 
   function requestVerify (options, next) {
-    const badRequestError = new BadRequest('Format is Authorization: Bearer [token]')
-
     if (typeof options === 'function' && !next) {
       next = options
       options = Object.assign({}, verifyOptions)
@@ -189,10 +193,10 @@ function fastifyJwt (fastify, options, next) {
         token = parts[1]
 
         if (!/^Bearer$/i.test(scheme)) {
-          return next(badRequestError)
+          return next(new BadRequest(badRequestErrorMessage))
         }
       } else {
-        return next(badRequestError)
+        return next(new BadRequest(badRequestErrorMessage))
       }
     } else {
       return next(new Unauthorized('No Authorization was found in request.headers'))

--- a/jwt.js
+++ b/jwt.js
@@ -189,6 +189,8 @@ function fastifyJwt (fastify, options, next) {
         if (!/^Bearer$/i.test(scheme)) {
           return next(new BadRequest('Format is Authorization: Bearer [token]'))
         }
+      } else {
+        return next(new BadRequest('Format is Authorization: Bearer [token]'))
       }
     } else {
       return next(new Unauthorized('No Authorization was found in request.headers'))

--- a/test.js
+++ b/test.js
@@ -194,10 +194,7 @@ test('register', function (t) {
     })
 
     fastify.get('/verify', function (request, reply) {
-      request.jwtVerify()
-        .then(function (decodedToken) {
-          return reply.send(decodedToken)
-        })
+      return request.jwtVerify()
     })
 
     fastify
@@ -287,9 +284,7 @@ test('sign and verify with HS-secret', function (t) {
     })
 
     fastify.get('/verifySync', function (request, reply) {
-      return request.jwtVerify().then(function (decodedToken) {
-        return reply.send(decodedToken)
-      })
+      return request.jwtVerify()
     })
 
     fastify.post('/signAsync', function (request, reply) {
@@ -328,7 +323,7 @@ test('sign and verify with HS-secret', function (t) {
               const decodedToken = JSON.parse(verifyResponse.payload)
               t.is(decodedToken.foo, 'bar')
             })
-          })
+          }).catch(t.threw)
         })
 
         t.test('with callbacks', function (t) {
@@ -352,7 +347,7 @@ test('sign and verify with HS-secret', function (t) {
               const decodedToken = JSON.parse(verifyResponse.payload)
               t.is(decodedToken.foo, 'bar')
             })
-          })
+          }).catch(t.threw)
         })
       })
   })
@@ -438,10 +433,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
       })
 
       fastify.get('/verifySync', function (request, reply) {
-        request.jwtVerify()
-          .then(function (decodedToken) {
-            return reply.send(decodedToken)
-          })
+        return request.jwtVerify()
       })
 
       fastify.post('/signAsync', function (request, reply) {
@@ -481,7 +473,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.iss, 'test')
               })
-            })
+            }).catch(t.threw)
           })
 
           t.test('with callbacks', function (t) {
@@ -506,7 +498,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.iss, 'test')
               })
-            })
+            }).catch(t.threw)
           })
         })
     })
@@ -589,10 +581,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
       })
 
       fastify.get('/verifySync', function (request, reply) {
-        request.jwtVerify()
-          .then(function (decodedToken) {
-            return reply.send(decodedToken)
-          })
+        return request.jwtVerify()
       })
 
       fastify.post('/signAsync', function (request, reply) {
@@ -632,7 +621,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.sub, 'test')
               })
-            })
+            }).catch(t.threw)
           })
 
           t.test('with callbacks', function (t) {
@@ -657,7 +646,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.sub, 'test')
               })
-            })
+            }).catch(t.threw)
           })
         })
     })
@@ -739,10 +728,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
       })
 
       fastify.get('/verifySync', function (request, reply) {
-        request.jwtVerify()
-          .then(function (decodedToken) {
-            return reply.send(decodedToken)
-          })
+        return request.jwtVerify()
       })
 
       fastify.post('/signAsync', function (request, reply) {
@@ -782,7 +768,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.aud, 'test')
                 t.is(decodedToken.foo, 'bar')
               })
-            })
+            }).catch(t.threw)
           })
 
           t.test('with callbacks', function (t) {
@@ -807,7 +793,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.aud, 'test')
                 t.is(decodedToken.foo, 'bar')
               })
-            })
+            }).catch(t.threw)
           })
         })
     })
@@ -889,10 +875,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
       })
 
       fastify.get('/verifySync', function (request, reply) {
-        request.jwtVerify()
-          .then(function (decodedToken) {
-            return reply.send(decodedToken)
-          })
+        return request.jwtVerify()
       })
 
       fastify.post('/signAsync', function (request, reply) {
@@ -932,7 +915,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.sub, 'test')
               })
-            })
+            }).catch(t.threw)
           })
 
           t.test('with callbacks', function (t) {
@@ -957,7 +940,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.sub, 'test')
               })
-            })
+            }).catch(t.threw)
           })
         })
     })
@@ -1046,10 +1029,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
       })
 
       fastify.get('/verifySync', function (request, reply) {
-        request.jwtVerify()
-          .then(function (decodedToken) {
-            return reply.send(decodedToken)
-          })
+        return request.jwtVerify()
       })
 
       fastify.post('/signAsync', function (request, reply) {
@@ -1089,7 +1069,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.iss, 'test')
               })
-            })
+            }).catch(t.threw)
           })
 
           t.test('with callbacks', function (t) {
@@ -1114,7 +1094,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.iss, 'test')
               })
-            })
+            }).catch(t.threw)
           })
         })
     })

--- a/test.js
+++ b/test.js
@@ -217,7 +217,11 @@ test('register', function (t) {
           }).then(function (verifyResponse) {
             const decodedToken = JSON.parse(verifyResponse.payload)
             t.is(decodedToken.foo, 'bar')
+          }).catch(function (error) {
+            t.fail(error)
           })
+        }).catch(function (error) {
+          t.fail(error)
         })
       })
   })
@@ -322,8 +326,12 @@ test('sign and verify with HS-secret', function (t) {
             }).then(function (verifyResponse) {
               const decodedToken = JSON.parse(verifyResponse.payload)
               t.is(decodedToken.foo, 'bar')
+            }).catch(function (error) {
+              t.fail(error)
             })
-          }).catch(t.threw)
+          }).catch(function (error) {
+            t.fail(error)
+          })
         })
 
         t.test('with callbacks', function (t) {
@@ -346,8 +354,12 @@ test('sign and verify with HS-secret', function (t) {
             }).then(function (verifyResponse) {
               const decodedToken = JSON.parse(verifyResponse.payload)
               t.is(decodedToken.foo, 'bar')
+            }).catch(function (error) {
+              t.fail(error)
             })
-          }).catch(t.threw)
+          }).catch(function (error) {
+            t.fail(error)
+          })
         })
       })
   })
@@ -472,8 +484,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.iss, 'test')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
 
           t.test('with callbacks', function (t) {
@@ -497,8 +513,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.iss, 'test')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
         })
     })
@@ -620,8 +640,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.sub, 'test')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
 
           t.test('with callbacks', function (t) {
@@ -645,8 +669,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.sub, 'test')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
         })
     })
@@ -767,8 +795,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.aud, 'test')
                 t.is(decodedToken.foo, 'bar')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
 
           t.test('with callbacks', function (t) {
@@ -792,8 +824,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.aud, 'test')
                 t.is(decodedToken.foo, 'bar')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
         })
     })
@@ -914,8 +950,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.sub, 'test')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
 
           t.test('with callbacks', function (t) {
@@ -939,8 +979,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.sub, 'test')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
         })
     })
@@ -1068,8 +1112,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.iss, 'test')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
 
           t.test('with callbacks', function (t) {
@@ -1093,8 +1141,12 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
                 const decodedToken = JSON.parse(verifyResponse.payload)
                 t.is(decodedToken.foo, 'bar')
                 t.is(decodedToken.iss, 'test')
+              }).catch(function (error) {
+                t.fail(error)
               })
-            }).catch(t.threw)
+            }).catch(function (error) {
+              t.fail(error)
+            })
           })
         })
     })

--- a/test.js
+++ b/test.js
@@ -1,31 +1,31 @@
 'use strict'
 
-const fs = require('fs')
+const { readFileSync } = require('fs')
 const path = require('path')
 const test = require('tap').test
 const Fastify = require('fastify')
 
 const jwt = require('./jwt')
 
-const privateKey = fs.readFileSync(`${path.join(__dirname, 'certs')}/private.key`, 'utf8')
-const publicKey = fs.readFileSync(`${path.join(__dirname, 'certs')}/public.key`, 'utf8')
+const privateKey = readFileSync(`${path.join(__dirname, 'certs')}/private.key`, 'utf8')
+const publicKey = readFileSync(`${path.join(__dirname, 'certs')}/public.key`, 'utf8')
 
 // passphrase used to protect the private key: super secret passphrase
-const privateKeyProtected = fs.readFileSync(`${path.join(__dirname, 'certs')}/private.pem`)
-const publicKeyProtected = fs.readFileSync(`${path.join(__dirname, 'certs')}/public.pem`)
+const privateKeyProtected = readFileSync(`${path.join(__dirname, 'certs')}/private.pem`)
+const publicKeyProtected = readFileSync(`${path.join(__dirname, 'certs')}/public.pem`)
 
-const privateKeyECDSA = fs.readFileSync(`${path.join(__dirname, 'certs')}/privateECDSA.key`, 'utf8')
-const publicKeyECDSA = fs.readFileSync(`${path.join(__dirname, 'certs')}/publicECDSA.key`, 'utf8')
+const privateKeyECDSA = readFileSync(`${path.join(__dirname, 'certs')}/privateECDSA.key`, 'utf8')
+const publicKeyECDSA = readFileSync(`${path.join(__dirname, 'certs')}/publicECDSA.key`, 'utf8')
 
 // passphrase used to protect the private key: super secret passphrase
-const privateKeyProtectedECDSA = fs.readFileSync(`${path.join(__dirname, 'certs')}/privateECDSA.pem`)
-const publicKeyProtectedECDSA = fs.readFileSync(`${path.join(__dirname, 'certs')}/publicECDSA.pem`)
+const privateKeyProtectedECDSA = readFileSync(`${path.join(__dirname, 'certs')}/privateECDSA.pem`)
+const publicKeyProtectedECDSA = readFileSync(`${path.join(__dirname, 'certs')}/publicECDSA.pem`)
 
 test('register', function (t) {
-  t.plan(9)
+  t.plan(7)
 
-  t.test('expose jwt methods', function (t) {
-    t.plan(6)
+  t.test('Expose jwt methods', function (t) {
+    t.plan(7)
 
     const fastify = Fastify()
     fastify.register(jwt, { secret: 'test' })
@@ -37,9 +37,10 @@ test('register', function (t) {
 
     fastify.ready(function () {
       t.ok(fastify.jwt.decode)
+      t.ok(fastify.jwt.options)
+      t.ok(fastify.jwt.secret)
       t.ok(fastify.jwt.sign)
       t.ok(fastify.jwt.verify)
-      t.ok(fastify.jwt.secret)
     })
 
     fastify.inject({
@@ -53,20 +54,26 @@ test('register', function (t) {
     const fastify = Fastify()
     fastify.register(jwt, {
       secret: {
-        private: privateKeyProtected,
-        public: 'super secret passphrase'
+        private: privateKey,
+        public: publicKey
       }
     }).ready(function (error) {
       t.is(error, null)
     })
   })
 
-  t.test('options as an object with default HS algorithm', function (t) {
+  t.test('decode, sign and verify global options (with default HS algorithm)', function (t) {
     t.plan(1)
     const fastify = Fastify()
     fastify.register(jwt, {
       secret: 'test',
-      options: {
+      decode: { complete: true },
+      sign: {
+        issuer: 'Some issuer',
+        subject: 'Some subject',
+        audience: 'Some audience'
+      },
+      verify: {
         issuer: 'Some issuer',
         subject: 'Some subject',
         audience: 'Some audience'
@@ -76,73 +83,96 @@ test('register', function (t) {
     })
   })
 
-  t.test('options and secret as an object with RS algorithm', function (t) {
-    t.plan(1)
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: privateKey,
-        public: publicKey
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'RS256'
-      }
-    }).ready(function (error) {
-      t.is(error, null)
+  t.test('decode, sign and verify global options and secret as an object', function (t) {
+    t.plan(2)
+
+    t.test('RS algorithm signed certificates', function (t) {
+      t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: privateKey,
+          public: publicKey
+        },
+        decode: { complete: true },
+        sign: {
+          algorithm: 'RS256',
+          audience: 'Some audience',
+          issuer: 'Some issuer',
+          subject: 'Some subject'
+        },
+        verify: {
+          algorithms: ['RS256'],
+          audience: 'Some audience',
+          issuer: 'Some issuer',
+          subject: 'Some subject'
+        }
+      }).ready(function (error) {
+        t.is(error, null)
+      })
+    })
+
+    t.test('ES algorithm signed certificates', function (t) {
+      t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: privateKeyECDSA,
+          public: publicKeyECDSA
+        },
+        decode: { complete: true },
+        sign: {
+          algorithm: 'ES256',
+          audience: 'Some audience',
+          issuer: 'Some issuer',
+          subject: 'Some subject'
+        },
+        verify: {
+          algorithms: ['ES256'],
+          audience: 'Some audience',
+          issuer: 'Some issuer',
+          subject: 'Some subject'
+        }
+      }).ready(function (error) {
+        t.is(error, null)
+      })
     })
   })
 
-  t.test('options and secret as an object with ES algorithm', function (t) {
-    t.plan(1)
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: privateKeyECDSA,
-        public: publicKeyECDSA
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'ES256'
-      }
-    }).ready(function (error) {
-      t.is(error, null)
-    })
-  })
+  t.test('RS/ES algorithm in sign options and secret as string', function (t) {
+    t.plan(2)
 
-  t.test('secret as string, options as an object with RS algorithm', function (t) {
-    t.plan(1)
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: 'test',
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'RS256'
-      }
-    }).ready(function (error) {
-      t.is(error.message, 'RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
-    })
-  })
+    t.test('RS algorithm (Must return an error)', function (t) {
+      t.plan(1)
 
-  t.test('secret as string, options as an object with ES algorithm', function (t) {
-    t.plan(1)
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: 'test',
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'ES256'
-      }
-    }).ready(function (error) {
-      t.is(error.message, 'ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'test',
+        sign: {
+          algorithm: 'RS256',
+          audience: 'Some audience',
+          issuer: 'Some issuer',
+          subject: 'Some subject'
+        }
+      }).ready(function (error) {
+        t.is(error.message, 'RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+      })
+    })
+
+    t.test('ES algorithm (Must return an error)', function (t) {
+      t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'test',
+        sign: {
+          algorithm: 'ES256',
+          audience: 'Some audience',
+          issuer: 'Some issuer',
+          subject: 'Some subject'
+        }
+      }).ready(function (error) {
+        t.is(error.message, 'ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+      })
     })
   })
 
@@ -328,592 +358,845 @@ test('sign and verify with HS-secret', function (t) {
   })
 })
 
-test('sign and verify with RSA and options', function (t) {
-  t.plan(2)
+test('sign and verify with RSA/ECDSA certificates and global options', function (t) {
+  t.plan(5)
 
-  t.test('server methods', function (t) {
+  t.test('RSA certificates', function (t) {
     t.plan(2)
 
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: privateKey,
-        public: publicKey
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'RS256'
-      }
-    })
+    t.test('server methods', function (t) {
+      t.plan(2)
 
-    fastify
-      .ready()
-      .then(function () {
-        t.test('synchronous', function (t) {
-          t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: privateKey,
+          public: publicKey
+        },
+        sign: {
+          algorithm: 'RS256',
+          issuer: 'test'
+        },
+        verify: {
+          algorithms: ['RS256'],
+          issuer: 'test'
+        }
+      })
 
-          const token = fastify.jwt.sign({ foo: 'bar' })
-          const decoded = fastify.jwt.verify(token)
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(2)
 
-          t.is(decoded.foo, 'bar')
-        })
+            const token = fastify.jwt.sign({ foo: 'bar' })
+            const decoded = fastify.jwt.verify(token)
 
-        t.test('with callbacks', function (t) {
-          t.plan(3)
+            t.is(decoded.foo, 'bar')
+            t.is(decoded.iss, 'test')
+          })
 
-          fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
-            t.error(error)
+          t.test('with callbacks', function (t) {
+            t.plan(4)
 
-            fastify.jwt.verify(token, function (error, decoded) {
+            fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
               t.error(error)
-              t.is(decoded.foo, 'bar')
+
+              fastify.jwt.verify(token, function (error, decoded) {
+                t.error(error)
+                t.is(decoded.foo, 'bar')
+                t.is(decoded.iss, 'test')
+              })
             })
           })
         })
-      })
-  })
-
-  t.test('route methods', function (t) {
-    t.plan(2)
-
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: privateKey,
-        public: publicKey
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'RS256'
-      }
     })
 
-    fastify.post('/signSync', function (request, reply) {
-      reply.jwtSign(request.body)
-        .then(function (token) {
-          return reply.send({ token })
+    t.test('route methods', function (t) {
+      t.plan(2)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: privateKey,
+          public: publicKey
+        },
+        sign: {
+          algorithm: 'RS256',
+          issuer: 'test'
+        },
+        verify: {
+          issuer: 'test'
+        }
+      })
+
+      fastify.post('/signSync', function (request, reply) {
+        reply.jwtSign(request.body)
+          .then(function (token) {
+            return reply.send({ token })
+          })
+      })
+
+      fastify.get('/verifySync', function (request, reply) {
+        request.jwtVerify()
+          .then(function (decodedToken) {
+            return reply.send(decodedToken)
+          })
+      })
+
+      fastify.post('/signAsync', function (request, reply) {
+        reply.jwtSign(request.body, function (error, token) {
+          return reply.send(error || { token })
         })
-    })
+      })
 
-    fastify.get('/verifySync', function (request, reply) {
-      request.jwtVerify()
-        .then(function (decodedToken) {
-          return reply.send(decodedToken)
+      fastify.get('/verifyAsync', function (request, reply) {
+        request.jwtVerify(function (error, decodedToken) {
+          return reply.send(error || decodedToken)
         })
-    })
-
-    fastify.post('/signAsync', function (request, reply) {
-      reply.jwtSign(request.body, function (error, token) {
-        return reply.send(error || { token })
       })
-    })
 
-    fastify.get('/verifyAsync', function (request, reply) {
-      request.jwtVerify(function (error, decodedToken) {
-        return reply.send(error || decodedToken)
-      })
-    })
-
-    fastify
-      .ready()
-      .then(function () {
-        t.test('synchronous', function (t) {
-          t.plan(2)
-
-          fastify.inject({
-            method: 'post',
-            url: '/signSync',
-            payload: { foo: 'bar' }
-          }).then(function (signResponse) {
-            const token = JSON.parse(signResponse.payload).token
-            t.ok(token)
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(3)
 
             fastify.inject({
-              method: 'get',
-              url: '/verifySync',
-              headers: {
-                authorization: `Bearer ${token}`
-              }
-            }).then(function (verifyResponse) {
-              const decodedToken = JSON.parse(verifyResponse.payload)
-              t.is(decodedToken.foo, 'bar')
+              method: 'post',
+              url: '/signSync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifySync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.foo, 'bar')
+                t.is(decodedToken.iss, 'test')
+              })
             })
           })
-        })
 
-        t.test('with callbacks', function (t) {
-          t.plan(2)
-
-          fastify.inject({
-            method: 'post',
-            url: '/signAsync',
-            payload: { foo: 'bar' }
-          }).then(function (signResponse) {
-            const token = JSON.parse(signResponse.payload).token
-            t.ok(token)
+          t.test('with callbacks', function (t) {
+            t.plan(3)
 
             fastify.inject({
-              method: 'get',
-              url: '/verifyAsync',
-              headers: {
-                authorization: `Bearer ${token}`
-              }
-            }).then(function (verifyResponse) {
-              const decodedToken = JSON.parse(verifyResponse.payload)
-              t.is(decodedToken.foo, 'bar')
+              method: 'post',
+              url: '/signAsync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifyAsync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.foo, 'bar')
+                t.is(decodedToken.iss, 'test')
+              })
             })
           })
         })
-      })
+    })
   })
-})
 
-test('sign and verify with ECDSA and options', function (t) {
-  t.plan(2)
-
-  t.test('server methods', function (t) {
+  t.test('ECDSA certificates', function (t) {
     t.plan(2)
 
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: privateKeyECDSA,
-        public: publicKeyECDSA
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'ES256'
-      }
-    })
+    t.test('server methods', function (t) {
+      t.plan(2)
 
-    fastify
-      .ready()
-      .then(function () {
-        t.test('synchronous', function (t) {
-          t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: privateKeyECDSA,
+          public: publicKeyECDSA
+        },
+        sign: {
+          algorithm: 'ES256',
+          subject: 'test'
+        },
+        verify: {
+          algorithms: ['ES256'],
+          subject: 'test'
+        }
+      })
 
-          const token = fastify.jwt.sign({ foo: 'bar' })
-          const decoded = fastify.jwt.verify(token)
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(2)
 
-          t.is(decoded.foo, 'bar')
-        })
+            const token = fastify.jwt.sign({ foo: 'bar' })
+            const decoded = fastify.jwt.verify(token)
 
-        t.test('with callbacks', function (t) {
-          t.plan(3)
+            t.is(decoded.foo, 'bar')
+            t.is(decoded.sub, 'test')
+          })
 
-          fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
-            t.error(error)
+          t.test('with callbacks', function (t) {
+            t.plan(4)
 
-            fastify.jwt.verify(token, function (error, decoded) {
+            fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
               t.error(error)
-              t.is(decoded.foo, 'bar')
+
+              fastify.jwt.verify(token, function (error, decoded) {
+                t.error(error)
+                t.is(decoded.foo, 'bar')
+                t.is(decoded.sub, 'test')
+              })
             })
           })
         })
-      })
-  })
-
-  t.test('route methods', function (t) {
-    t.plan(2)
-
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: privateKeyECDSA,
-        public: publicKeyECDSA
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'ES256'
-      }
     })
 
-    fastify.post('/signSync', function (request, reply) {
-      reply.jwtSign(request.body)
-        .then(function (token) {
-          return reply.send({ token })
+    t.test('route methods', function (t) {
+      t.plan(2)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: privateKeyECDSA,
+          public: publicKeyECDSA
+        },
+        sign: {
+          algorithm: 'ES256',
+          subject: 'test'
+        },
+        verify: {
+          subject: 'test'
+        }
+      })
+
+      fastify.post('/signSync', function (request, reply) {
+        reply.jwtSign(request.body)
+          .then(function (token) {
+            return reply.send({ token })
+          })
+      })
+
+      fastify.get('/verifySync', function (request, reply) {
+        request.jwtVerify()
+          .then(function (decodedToken) {
+            return reply.send(decodedToken)
+          })
+      })
+
+      fastify.post('/signAsync', function (request, reply) {
+        reply.jwtSign(request.body, function (error, token) {
+          return reply.send(error || { token })
         })
-    })
+      })
 
-    fastify.get('/verifySync', function (request, reply) {
-      request.jwtVerify()
-        .then(function (decodedToken) {
-          return reply.send(decodedToken)
+      fastify.get('/verifyAsync', function (request, reply) {
+        request.jwtVerify(function (error, decodedToken) {
+          return reply.send(error || decodedToken)
         })
-    })
-
-    fastify.post('/signAsync', function (request, reply) {
-      reply.jwtSign(request.body, function (error, token) {
-        return reply.send(error || { token })
       })
-    })
 
-    fastify.get('/verifyAsync', function (request, reply) {
-      request.jwtVerify(function (error, decodedToken) {
-        return reply.send(error || decodedToken)
-      })
-    })
-
-    fastify
-      .ready()
-      .then(function () {
-        t.test('synchronous', function (t) {
-          t.plan(2)
-
-          fastify.inject({
-            method: 'post',
-            url: '/signSync',
-            payload: { foo: 'bar' }
-          }).then(function (signResponse) {
-            const token = JSON.parse(signResponse.payload).token
-            t.ok(token)
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(3)
 
             fastify.inject({
-              method: 'get',
-              url: '/verifySync',
-              headers: {
-                authorization: `Bearer ${token}`
-              }
-            }).then(function (verifyResponse) {
-              const decodedToken = JSON.parse(verifyResponse.payload)
-              t.is(decodedToken.foo, 'bar')
+              method: 'post',
+              url: '/signSync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifySync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.foo, 'bar')
+                t.is(decodedToken.sub, 'test')
+              })
             })
           })
-        })
 
-        t.test('with callbacks', function (t) {
-          t.plan(2)
-
-          fastify.inject({
-            method: 'post',
-            url: '/signAsync',
-            payload: { foo: 'bar' }
-          }).then(function (signResponse) {
-            const token = JSON.parse(signResponse.payload).token
-            t.ok(token)
+          t.test('with callbacks', function (t) {
+            t.plan(3)
 
             fastify.inject({
-              method: 'get',
-              url: '/verifyAsync',
-              headers: {
-                authorization: `Bearer ${token}`
-              }
-            }).then(function (verifyResponse) {
-              const decodedToken = JSON.parse(verifyResponse.payload)
-              t.is(decodedToken.foo, 'bar')
+              method: 'post',
+              url: '/signAsync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifyAsync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.foo, 'bar')
+                t.is(decodedToken.sub, 'test')
+              })
             })
           })
         })
-      })
+    })
   })
-})
 
-test('sign and verify with RSA passphrase protected private key (PEM file) and options', function (t) {
-  t.plan(2)
-
-  t.test('server methods', function (t) {
+  t.test('RSA certificates (passphrase protected)', function (t) {
     t.plan(2)
 
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: { key: privateKeyProtected, passphrase: 'super secret passphrase' },
-        public: publicKeyProtected
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'RS256'
-      }
-    })
+    t.test('server methods', function (t) {
+      t.plan(2)
 
-    fastify
-      .ready()
-      .then(function () {
-        t.test('synchronous', function (t) {
-          t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: { key: privateKeyProtected, passphrase: 'super secret passphrase' },
+          public: publicKeyProtected
+        },
+        sign: {
+          algorithm: 'RS256',
+          audience: 'test'
+        },
+        verify: {
+          audience: 'test'
+        }
+      })
 
-          const token = fastify.jwt.sign({ foo: 'bar' })
-          const decoded = fastify.jwt.verify(token)
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(2)
 
-          t.is(decoded.foo, 'bar')
-        })
+            const token = fastify.jwt.sign({ foo: 'bar' })
+            const decoded = fastify.jwt.verify(token)
 
-        t.test('with callbacks', function (t) {
-          t.plan(3)
+            t.is(decoded.aud, 'test')
+            t.is(decoded.foo, 'bar')
+          })
 
-          fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
-            t.error(error)
+          t.test('with callbacks', function (t) {
+            t.plan(4)
 
-            fastify.jwt.verify(token, function (error, decoded) {
+            fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
               t.error(error)
-              t.is(decoded.foo, 'bar')
+
+              fastify.jwt.verify(token, function (error, decoded) {
+                t.error(error)
+                t.is(decoded.aud, 'test')
+                t.is(decoded.foo, 'bar')
+              })
             })
           })
         })
-      })
-  })
-
-  t.test('route methods', function (t) {
-    t.plan(2)
-
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: { key: privateKeyProtected, passphrase: 'super secret passphrase' },
-        public: publicKeyProtected
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'RS256'
-      }
     })
 
-    fastify.post('/signSync', function (request, reply) {
-      reply.jwtSign(request.body)
-        .then(function (token) {
-          return reply.send({ token })
+    t.test('route methods', function (t) {
+      t.plan(2)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: { key: privateKeyProtected, passphrase: 'super secret passphrase' },
+          public: publicKeyProtected
+        },
+        sign: {
+          algorithm: 'RS256',
+          audience: 'test'
+        },
+        verify: {
+          audience: 'test'
+        }
+      })
+
+      fastify.post('/signSync', function (request, reply) {
+        reply.jwtSign(request.body)
+          .then(function (token) {
+            return reply.send({ token })
+          })
+      })
+
+      fastify.get('/verifySync', function (request, reply) {
+        request.jwtVerify()
+          .then(function (decodedToken) {
+            return reply.send(decodedToken)
+          })
+      })
+
+      fastify.post('/signAsync', function (request, reply) {
+        reply.jwtSign(request.body, function (error, token) {
+          return reply.send(error || { token })
         })
-    })
+      })
 
-    fastify.get('/verifySync', function (request, reply) {
-      request.jwtVerify()
-        .then(function (decodedToken) {
-          return reply.send(decodedToken)
+      fastify.get('/verifyAsync', function (request, reply) {
+        request.jwtVerify(function (error, decodedToken) {
+          return reply.send(error || decodedToken)
         })
-    })
-
-    fastify.post('/signAsync', function (request, reply) {
-      reply.jwtSign(request.body, function (error, token) {
-        return reply.send(error || { token })
       })
-    })
 
-    fastify.get('/verifyAsync', function (request, reply) {
-      request.jwtVerify(function (error, decodedToken) {
-        return reply.send(error || decodedToken)
-      })
-    })
-
-    fastify
-      .ready()
-      .then(function () {
-        t.test('synchronous', function (t) {
-          t.plan(2)
-
-          fastify.inject({
-            method: 'post',
-            url: '/signSync',
-            payload: { foo: 'bar' }
-          }).then(function (signResponse) {
-            const token = JSON.parse(signResponse.payload).token
-            t.ok(token)
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(3)
 
             fastify.inject({
-              method: 'get',
-              url: '/verifySync',
-              headers: {
-                authorization: `Bearer ${token}`
-              }
-            }).then(function (verifyResponse) {
-              const decodedToken = JSON.parse(verifyResponse.payload)
-              t.is(decodedToken.foo, 'bar')
+              method: 'post',
+              url: '/signSync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifySync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.aud, 'test')
+                t.is(decodedToken.foo, 'bar')
+              })
             })
           })
-        })
 
-        t.test('with callbacks', function (t) {
-          t.plan(2)
-
-          fastify.inject({
-            method: 'post',
-            url: '/signAsync',
-            payload: { foo: 'bar' }
-          }).then(function (signResponse) {
-            const token = JSON.parse(signResponse.payload).token
-            t.ok(token)
+          t.test('with callbacks', function (t) {
+            t.plan(3)
 
             fastify.inject({
-              method: 'get',
-              url: '/verifyAsync',
-              headers: {
-                authorization: `Bearer ${token}`
-              }
-            }).then(function (verifyResponse) {
-              const decodedToken = JSON.parse(verifyResponse.payload)
-              t.is(decodedToken.foo, 'bar')
+              method: 'post',
+              url: '/signAsync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifyAsync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.aud, 'test')
+                t.is(decodedToken.foo, 'bar')
+              })
             })
           })
         })
-      })
+    })
   })
-})
 
-test('sign and verify with ECDSA passphrase protected private key (PEM file) and options', function (t) {
-  t.plan(2)
-
-  t.test('server methods', function (t) {
+  t.test('ECDSA certificates (passphrase protected)', function (t) {
     t.plan(2)
 
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: { key: privateKeyProtectedECDSA, passphrase: 'super secret passphrase' },
-        public: publicKeyProtectedECDSA
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'ES256'
-      }
-    })
+    t.test('server methods', function (t) {
+      t.plan(2)
 
-    fastify
-      .ready()
-      .then(function () {
-        t.test('synchronous', function (t) {
-          t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: { key: privateKeyProtectedECDSA, passphrase: 'super secret passphrase' },
+          public: publicKeyProtectedECDSA
+        },
+        sign: {
+          algorithm: 'ES256',
+          subject: 'test'
+        },
+        verify: {
+          subject: 'test'
+        }
+      })
 
-          const token = fastify.jwt.sign({ foo: 'bar' })
-          const decoded = fastify.jwt.verify(token)
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(2)
 
-          t.is(decoded.foo, 'bar')
-        })
+            const token = fastify.jwt.sign({ foo: 'bar' })
+            const decoded = fastify.jwt.verify(token)
 
-        t.test('with callbacks', function (t) {
-          t.plan(3)
+            t.is(decoded.foo, 'bar')
+            t.is(decoded.sub, 'test')
+          })
 
-          fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
-            t.error(error)
+          t.test('with callbacks', function (t) {
+            t.plan(4)
 
-            fastify.jwt.verify(token, function (error, decoded) {
+            fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
               t.error(error)
-              t.is(decoded.foo, 'bar')
+
+              fastify.jwt.verify(token, function (error, decoded) {
+                t.error(error)
+                t.is(decoded.foo, 'bar')
+                t.is(decoded.sub, 'test')
+              })
             })
           })
         })
+    })
+
+    t.test('route methods', function (t) {
+      t.plan(2)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: { key: privateKeyProtectedECDSA, passphrase: 'super secret passphrase' },
+          public: publicKeyProtectedECDSA
+        },
+        sign: {
+          algorithm: 'ES256',
+          subject: 'test'
+        },
+        verify: {
+          subject: 'test'
+        }
       })
+
+      fastify.post('/signSync', function (request, reply) {
+        reply.jwtSign(request.body)
+          .then(function (token) {
+            return reply.send({ token })
+          })
+      })
+
+      fastify.get('/verifySync', function (request, reply) {
+        request.jwtVerify()
+          .then(function (decodedToken) {
+            return reply.send(decodedToken)
+          })
+      })
+
+      fastify.post('/signAsync', function (request, reply) {
+        reply.jwtSign(request.body, function (error, token) {
+          return reply.send(error || { token })
+        })
+      })
+
+      fastify.get('/verifyAsync', function (request, reply) {
+        request.jwtVerify(function (error, decodedToken) {
+          return reply.send(error || decodedToken)
+        })
+      })
+
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(3)
+
+            fastify.inject({
+              method: 'post',
+              url: '/signSync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifySync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.foo, 'bar')
+                t.is(decodedToken.sub, 'test')
+              })
+            })
+          })
+
+          t.test('with callbacks', function (t) {
+            t.plan(3)
+
+            fastify.inject({
+              method: 'post',
+              url: '/signAsync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifyAsync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.foo, 'bar')
+                t.is(decodedToken.sub, 'test')
+              })
+            })
+          })
+        })
+    })
   })
 
-  t.test('route methods', function (t) {
+  t.test('Overriding global options', function (t) {
     t.plan(2)
 
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: {
-        private: { key: privateKeyProtectedECDSA, passphrase: 'super secret passphrase' },
-        public: publicKeyProtectedECDSA
-      },
-      options: {
-        issuer: 'Some issuer',
-        subject: 'Some subject',
-        audience: 'Some audience',
-        algorithm: 'ES256'
-      }
-    })
+    t.test('server methods', function (t) {
+      t.plan(2)
 
-    fastify.post('/signSync', function (request, reply) {
-      reply.jwtSign(request.body)
-        .then(function (token) {
-          return reply.send({ token })
-        })
-    })
-
-    fastify.get('/verifySync', function (request, reply) {
-      request.jwtVerify()
-        .then(function (decodedToken) {
-          return reply.send(decodedToken)
-        })
-    })
-
-    fastify.post('/signAsync', function (request, reply) {
-      reply.jwtSign(request.body, function (error, token) {
-        return reply.send(error || { token })
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: privateKey,
+          public: publicKey
+        },
+        sign: {
+          algorithm: 'RS256',
+          issuer: 'test'
+        },
+        verify: {
+          algorithms: ['RS256'],
+          issuer: 'test'
+        }
       })
-    })
 
-    fastify.get('/verifyAsync', function (request, reply) {
-      request.jwtVerify(function (error, decodedToken) {
-        return reply.send(error || decodedToken)
-      })
-    })
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(2)
 
-    fastify
-      .ready()
-      .then(function () {
-        t.test('synchronous', function (t) {
-          t.plan(2)
+            let localOptions = Object.assign({}, fastify.jwt.options.sign)
+            localOptions.issuer = 'other'
 
-          fastify.inject({
-            method: 'post',
-            url: '/signSync',
-            payload: { foo: 'bar' }
-          }).then(function (signResponse) {
-            const token = JSON.parse(signResponse.payload).token
-            t.ok(token)
+            const token = fastify.jwt.sign({ foo: 'bar' }, localOptions)
+            const decoded = fastify.jwt.verify(token, { issuer: 'other' })
 
-            fastify.inject({
-              method: 'get',
-              url: '/verifySync',
-              headers: {
-                authorization: `Bearer ${token}`
-              }
-            }).then(function (verifyResponse) {
-              const decodedToken = JSON.parse(verifyResponse.payload)
-              t.is(decodedToken.foo, 'bar')
+            t.is(decoded.foo, 'bar')
+            t.is(decoded.iss, 'other')
+          })
+
+          t.test('with callbacks', function (t) {
+            t.plan(4)
+
+            let localOptions = Object.assign({}, fastify.jwt.options.sign)
+            localOptions.issuer = 'other'
+
+            fastify.jwt.sign({ foo: 'bar' }, localOptions, function (error, token) {
+              t.error(error)
+
+              fastify.jwt.verify(token, { issuer: 'other' }, function (error, decoded) {
+                t.error(error)
+                t.is(decoded.foo, 'bar')
+                t.is(decoded.iss, 'other')
+              })
             })
           })
         })
+    })
 
-        t.test('with callbacks', function (t) {
-          t.plan(2)
+    t.test('route methods', function (t) {
+      t.plan(2)
 
-          fastify.inject({
-            method: 'post',
-            url: '/signAsync',
-            payload: { foo: 'bar' }
-          }).then(function (signResponse) {
-            const token = JSON.parse(signResponse.payload).token
-            t.ok(token)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: {
+          private: privateKey,
+          public: publicKey
+        },
+        sign: {
+          algorithm: 'RS256',
+          issuer: 'test'
+        },
+        verify: {
+          issuer: 'test'
+        }
+      })
+
+      fastify.post('/signSync', function (request, reply) {
+        reply.jwtSign(request.body)
+          .then(function (token) {
+            return reply.send({ token })
+          })
+      })
+
+      fastify.get('/verifySync', function (request, reply) {
+        request.jwtVerify()
+          .then(function (decodedToken) {
+            return reply.send(decodedToken)
+          })
+      })
+
+      fastify.post('/signAsync', function (request, reply) {
+        reply.jwtSign(request.body, function (error, token) {
+          return reply.send(error || { token })
+        })
+      })
+
+      fastify.get('/verifyAsync', function (request, reply) {
+        request.jwtVerify(function (error, decodedToken) {
+          return reply.send(error || decodedToken)
+        })
+      })
+
+      fastify
+        .ready()
+        .then(function () {
+          t.test('synchronous', function (t) {
+            t.plan(3)
 
             fastify.inject({
-              method: 'get',
-              url: '/verifyAsync',
-              headers: {
-                authorization: `Bearer ${token}`
-              }
-            }).then(function (verifyResponse) {
-              const decodedToken = JSON.parse(verifyResponse.payload)
-              t.is(decodedToken.foo, 'bar')
+              method: 'post',
+              url: '/signSync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifySync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.foo, 'bar')
+                t.is(decodedToken.iss, 'test')
+              })
+            })
+          })
+
+          t.test('with callbacks', function (t) {
+            t.plan(3)
+
+            fastify.inject({
+              method: 'post',
+              url: '/signAsync',
+              payload: { foo: 'bar' }
+            }).then(function (signResponse) {
+              const token = JSON.parse(signResponse.payload).token
+              t.ok(token)
+
+              fastify.inject({
+                method: 'get',
+                url: '/verifyAsync',
+                headers: {
+                  authorization: `Bearer ${token}`
+                }
+              }).then(function (verifyResponse) {
+                const decodedToken = JSON.parse(verifyResponse.payload)
+                t.is(decodedToken.foo, 'bar')
+                t.is(decodedToken.iss, 'test')
+              })
             })
           })
         })
-      })
+    })
   })
 })
 
 test('decode', function (t) {
-  t.plan(1)
+  t.plan(2)
 
-  const fastify = Fastify()
-  fastify.register(jwt, { secret: 'test' })
+  t.test('without global options', function (t) {
+    t.plan(2)
 
-  fastify.ready(function () {
-    const token = fastify.jwt.sign({ foo: 'bar' })
-    const decoded = fastify.jwt.decode(token)
-    t.is(decoded.foo, 'bar')
+    t.test('without local options', function (t) {
+      t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, { secret: 'test' })
+
+      fastify.ready(function () {
+        const token = fastify.jwt.sign({ foo: 'bar' })
+        const decoded = fastify.jwt.decode(token)
+        t.is(decoded.foo, 'bar')
+      })
+    })
+
+    t.test('with local options', function (t) {
+      t.plan(3)
+
+      const fastify = Fastify()
+      fastify.register(jwt, { secret: 'test' })
+
+      fastify.ready(function () {
+        const token = fastify.jwt.sign({ foo: 'bar' })
+        const decoded = fastify.jwt.decode(token, { complete: true })
+
+        t.is(decoded.header.alg, 'HS256')
+        t.is(decoded.header.typ, 'JWT')
+        t.is(decoded.payload.foo, 'bar')
+      })
+    })
+  })
+
+  t.test('with global options', function (t) {
+    t.plan(2)
+
+    t.test('without overriding global options', function (t) {
+      t.plan(3)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'test',
+        decode: { complete: true }
+      })
+
+      fastify.ready(function () {
+        const token = fastify.jwt.sign({ foo: 'bar' })
+        const decoded = fastify.jwt.decode(token)
+
+        t.is(decoded.header.alg, 'HS256')
+        t.is(decoded.header.typ, 'JWT')
+        t.is(decoded.payload.foo, 'bar')
+      })
+    })
+
+    t.test('overriding global options', function (t) {
+      t.plan(4)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'test',
+        decode: { complete: true }
+      })
+
+      fastify.ready(function () {
+        const token = fastify.jwt.sign({ foo: 'bar' })
+        const decoded = fastify.jwt.decode(token, { complete: false })
+
+        t.is(decoded.header, undefined)
+        t.is(decoded.payload, undefined)
+        t.is(decoded.signature, undefined)
+        t.is(decoded.foo, 'bar')
+      })
+    })
   })
 })
 

--- a/test.js
+++ b/test.js
@@ -22,7 +22,7 @@ const privateKeyProtectedECDSA = readFileSync(`${path.join(__dirname, 'certs')}/
 const publicKeyProtectedECDSA = readFileSync(`${path.join(__dirname, 'certs')}/publicECDSA.pem`)
 
 test('register', function (t) {
-  t.plan(8)
+  t.plan(9)
 
   t.test('Expose jwt methods', function (t) {
     t.plan(7)
@@ -59,6 +59,20 @@ test('register', function (t) {
       }
     }).ready(function (error) {
       t.is(error, null)
+    })
+  })
+
+  t.test('deprecated use of options prefix', function (t) {
+    t.plan(1)
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: {
+        private: privateKey,
+        public: publicKey
+      },
+      options: { algorithme: 'RS256' }
+    }).ready(function (error) {
+      t.is(error.message, 'options prefix is deprecated')
     })
   })
 


### PR DESCRIPTION
Address this feature proposal : https://github.com/fastify/fastify-jwt/issues/27#issue-373060330

Currently i have already done this:
- [x] options management implementation
- [x] wrote the tests
- [x] a big refactoring of the tests to make them more readable and organized
- [x] documenting the options
- [x] a little refactoring of the documentation

What needs to be done :
- [ ] typescript definitions
- [ ] implement an `algorithm` prefix to avoid any code breaking and mark it as deprecated before we simply delete it and force the new recommended options management.

Concerning the `algorithm` prefix do you think it's really worth doing it ? (I already have a commit ready if needed)
IMO it's the better way to transition through the actual `0.6.0` version and the `0.8.0` or `0.9.0` versions (if we consider this PR will land with the version `0.7.0`) and thus giving users the time they need to adopt the new recommended options management.