### PR TITLE
Respond with 401 instead of 500 if token is expired

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -210,7 +210,7 @@ function fastifyJwt (fastify, options, next) {
       },
       function verify (secretOrPublicKey, callback) {
         jwt.verify(token, secretOrPublicKey, options, (err, result) => {
-          if (err && err instanceof jwt.TokenExpiredError) {
+          if (err instanceof jwt.TokenExpiredError) {
             return callback(new Unauthorized('Authorization token expired'))
           }
           callback(err, result)

--- a/jwt.js
+++ b/jwt.js
@@ -209,7 +209,12 @@ function fastifyJwt (fastify, options, next) {
         secretCallbackVerify(request, decodedToken, callback)
       },
       function verify (secretOrPublicKey, callback) {
-        jwt.verify(token, secretOrPublicKey, options, callback)
+        jwt.verify(token, secretOrPublicKey, options, (err, result) => {
+          if (err && err instanceof jwt.TokenExpiredError) {
+            return callback(new Unauthorized('Authorization token expired'))
+          }
+          callback(err, result)
+        })
       }
     ], function (err, result) {
       if (err) next(err)

--- a/test.js
+++ b/test.js
@@ -1288,7 +1288,7 @@ test('decode', function (t) {
 })
 
 test('errors', function (t) {
-  t.plan(5)
+  t.plan(6)
 
   const fastify = Fastify()
   fastify.register(jwt, { secret: 'test' })
@@ -1383,6 +1383,26 @@ test('errors', function (t) {
           const error = JSON.parse(response.payload)
           t.is(error.message, 'Format is Authorization: Bearer [token]')
           t.is(response.statusCode, 400)
+        })
+      })
+
+      t.test('Expired token error', function (t) {
+        t.plan(2)
+
+        const expiredToken = fastify.jwt.sign({
+          exp: Math.floor(Date.now() / 1000) - 60,
+          foo: 'bar'
+        })
+        fastify.inject({
+          method: 'get',
+          url: '/verify',
+          headers: {
+            authorization: `Bearer ${expiredToken}`
+          }
+        }).then(function (response) {
+          const error = JSON.parse(response.payload)
+          t.is(error.message, 'Authorization token expired')
+          t.is(response.statusCode, 401)
         })
       })
 


### PR DESCRIPTION
Previously you'd get an "Internal Server Error" which sounds like it's the server's fault and out of the user's control, but an expired token is actually actionable for users