### PR TITLE
Return 401 for all invalid tokens

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -213,6 +213,10 @@ function fastifyJwt (fastify, options, next) {
           if (err instanceof jwt.TokenExpiredError) {
             return callback(new Unauthorized('Authorization token expired'))
           }
+          // These can all be fixed by obtaining a new JWT, should not return 500
+          if (err instanceof jwt.JsonWebTokenError) {
+            return callback(new Unauthorized('Authorization token is invalid: ' + err.message))
+          }
           callback(err, result)
         })
       }

--- a/jwt.js
+++ b/jwt.js
@@ -213,7 +213,6 @@ function fastifyJwt (fastify, options, next) {
           if (err instanceof jwt.TokenExpiredError) {
             return callback(new Unauthorized('Authorization token expired'))
           }
-          // These can all be fixed by obtaining a new JWT, should not return 500
           if (err instanceof jwt.JsonWebTokenError) {
             return callback(new Unauthorized('Authorization token is invalid: ' + err.message))
           }


### PR DESCRIPTION
"internal server error" is not really accurate for an invalid/malformed token. having an invalid token is something users can normally solve (just get a new one), so 401 seems more appropriate