### PR TITLE
fix for passing Buffer object as secretOrPublicKey

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -30,7 +30,7 @@ function fastifyJwt (fastify, options, next) {
   let secretOrPrivateKey
   let secretOrPublicKey
 
-  if (typeof secret === 'object' && !secret instanceof Buffer) {
+  if (typeof secret === 'object' && !Buffer.isBuffer(secret)) {
     if (!secret.private || !secret.public) {
       return next(new Error('missing private key and/or public key'))
     }

--- a/jwt.js
+++ b/jwt.js
@@ -53,7 +53,8 @@ function fastifyJwt (fastify, options, next) {
     signOptions &&
     signOptions.algorithm &&
     signOptions.algorithm.includes('RS') &&
-    typeof secret === 'string'
+    (typeof secret === 'string' ||
+    Buffer.isBuffer(secret))
   ) {
     return next(new Error(`RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret`))
   }
@@ -61,7 +62,8 @@ function fastifyJwt (fastify, options, next) {
     signOptions &&
     signOptions.algorithm &&
     signOptions.algorithm.includes('ES') &&
-    typeof secret === 'string'
+    (typeof secret === 'string' ||
+    Buffer.isBuffer(secret))
   ) {
     return next(new Error(`ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret`))
   }

--- a/jwt.js
+++ b/jwt.js
@@ -30,7 +30,7 @@ function fastifyJwt (fastify, options, next) {
   let secretOrPrivateKey
   let secretOrPublicKey
 
-  if (typeof secret === 'object') {
+  if (typeof secret === 'object' && !secret instanceof Buffer) {
     if (!secret.private || !secret.public) {
       return next(new Error('missing private key and/or public key'))
     }

--- a/jwt.js
+++ b/jwt.js
@@ -54,7 +54,7 @@ function fastifyJwt (fastify, options, next) {
     signOptions.algorithm &&
     signOptions.algorithm.includes('RS') &&
     (typeof secret === 'string' ||
-    Buffer.isBuffer(secret))
+    secret instanceof Buffer)
   ) {
     return next(new Error(`RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret`))
   }
@@ -63,7 +63,7 @@ function fastifyJwt (fastify, options, next) {
     signOptions.algorithm &&
     signOptions.algorithm.includes('ES') &&
     (typeof secret === 'string' ||
-    Buffer.isBuffer(secret))
+    secret instanceof Buffer)
   ) {
     return next(new Error(`ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret`))
   }

--- a/test.js
+++ b/test.js
@@ -23,7 +23,7 @@ const privateKeyProtectedECDSA = readFileSync(`${path.join(__dirname, 'certs')}/
 const publicKeyProtectedECDSA = readFileSync(`${path.join(__dirname, 'certs')}/publicECDSA.pem`)
 
 test('register', function (t) {
-  t.plan(9)
+  t.plan(11)
 
   t.test('Expose jwt methods', function (t) {
     t.plan(7)
@@ -58,6 +58,16 @@ test('register', function (t) {
         private: privateKey,
         public: publicKey
       }
+    }).ready(function (error) {
+      t.is(error, null)
+    })
+  })
+
+  t.test('secret as a Buffer', function (t) {
+    t.plan(1)
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: Buffer.from('some secret', 'base64')
     }).ready(function (error) {
       t.is(error, null)
     })
@@ -220,6 +230,43 @@ test('register', function (t) {
       const fastify = Fastify()
       fastify.register(jwt, {
         secret: 'test',
+        sign: {
+          algorithm: 'ES256',
+          audience: 'Some audience',
+          issuer: 'Some issuer',
+          subject: 'Some subject'
+        }
+      }).ready(function (error) {
+        t.is(error.message, 'ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+      })
+    })
+  })
+
+  t.test('RS/ES algorithm in sign options and secret as a Buffer', function (t) {
+    t.plan(2)
+
+    t.test('RS algorithm (Must return an error)', function (t) {
+      t.plan(1)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: Buffer.from('some secret', 'base64'),
+        sign: {
+          algorithm: 'RS256',
+          audience: 'Some audience',
+          issuer: 'Some issuer',
+          subject: 'Some subject'
+        }
+      }).ready(function (error) {
+        t.is(error.message, 'RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+      })
+    })
+
+    t.test('ES algorithm (Must return an error)', function (t) {
+      t.plan(1)
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: Buffer.from('some secret', 'base64'),
         sign: {
           algorithm: 'ES256',
           audience: 'Some audience',


### PR DESCRIPTION
Hi!

While moving one of my projects from Express to Fastify I noticed `fastify-jwt` doesn't handle `Buffer` objects passed as `options.secret` in a correct way, causing JWT verification attempts to fail. I'm working with a Twitch.tv extension and it [expects me to verify tokens with Buffer objects](https://discuss.dev.twitch.tv/t/invalid-signature-attempting-to-verify-token-node-js/12146). I was able to do it with `jsonwebtoken` and `Buffer.from(...)`, but `fastify-jwt` throws `Error('missing private key and/or public key')`.

I made a quick fix that causes the project to pass `Buffer` objects directly to `secretOrPublicKey` variable, making it possible to successfuly verify JWTs in cases like the one I described above.

~~Alternatively, `!Buffer.isBuffer(secret)` can also be used as a condition.~~