### PR TITLE
Allow base64 buffer for node-jwt

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -30,7 +30,7 @@ function fastifyJwt (fastify, options, next) {
   let secretOrPrivateKey
   let secretOrPublicKey
 
-  if (typeof secret === 'object') {
+  if (typeof secret === 'object' && !Buffer.isBuffer(secret)) {
     if (!secret.private || !secret.public) {
       return next(new Error('missing private key and/or public key'))
     }


### PR DESCRIPTION
As specified on [this readme](https://github.com/auth0/node-jsonwebtoken), it's possible to use a buffered base64 byte array.

Why is safer to use Base64 byte array?
https://github.com/auth0/node-jsonwebtoken/issues/208#issuecomment-231861138