### PR TITLE
Fix double-invocation of callback in requestVerify

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -222,9 +222,12 @@ function fastifyJwt (fastify, options, next) {
         })
       }
     ], function (err, result) {
-      if (err) next(err)
-      request.user = result
-      next(null, result)
+      if (err) {
+        next(err)
+      } else {
+        request.user = result
+        next(null, result)
+      }
     })
   }
 }


### PR DESCRIPTION
Currently, if token verification fails inside `request.jwtVerify(options, callback)`, then `callback` winds up being invoked twice -- first with an error, and then without.

This appears to be due to a missing else clause (or a missing return statement) in the callback at the end of `requestVerify()` (currently lines 224-228 of jwt.js).

The fix is pretty simple; not sure if a test ought to be written for this, but happy to do so if needed.