### PR TITLE
Move @types/jsonwebtoken to dep list

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   },
   "homepage": "https://github.com/fastify/fastify-jwt#readme",
   "dependencies": {
+    "@types/jsonwebtoken": "^8.3.2",
     "fastify-plugin": "^1.2.0",
     "http-errors": "^1.7.1",
     "jsonwebtoken": "^8.3.0",
     "steed": "^1.1.3"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^8.3.0",
     "fastify": "^2.0.0",
     "standard": "^12.0.1",
     "tap": "^12.0.1",


### PR DESCRIPTION
I was able to fix the issue #50 by installing @types/jsonwebtoken as a dependency instead of a devDep. This makes sense as if you're shipping the `index.d.ts` and it is referencing types from `@types/jsonwebtoken` then you should be shipping those types with the package. 