### PR TITLE
Refactor type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,6 @@ declare interface FastifyJWTOptions {
   verify?: jwt.VerifyOptions;
 }
 
-declare const fastifyJWT: fastify.Plugin<http.Server, http.ClientRequest, http.ServerResponse, FastifyJWTOptions>;
+declare const fastifyJWT: fastify.Plugin<http.Server, http.IncomingMessage, http.ServerResponse, FastifyJWTOptions>;
 
 export = fastifyJWT;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,16 @@ import * as http from 'http';
 import * as jwt from 'jsonwebtoken';
 
 declare module 'fastify' {
+  namespace JWTTypes {
+    type PayloadType = object | string;
+
+    interface SignCallback extends jwt.SignCallback {}
+
+    interface VerifyCallback<Decoded extends PayloadType> extends jwt.VerifyCallback {
+      (err: jwt.VerifyErrors, decoded: Decoded): void;
+    }
+  }
+
   interface JWT {
     options: {
       decode: jwt.DecodeOptions;
@@ -10,17 +20,39 @@ declare module 'fastify' {
       verify: jwt.VerifyOptions;
     };
     secret: jwt.Secret;
-    sign: (payload: string | Buffer | object, options?: jwt.SignOptions, callback?: jwt.VerifyCallback) => string;
-    verify: (token: string, options?: jwt.VerifyOptions, callback?: jwt.VerifyCallback) => Promise<object | string>;
-    decode: (token: string, options?: jwt.DecodeOptions) => null | { [key: string]: any } | string;
+
+    sign(payload: JWTTypes.PayloadType | Buffer, options?: jwt.SignOptions): string;
+    sign(payload: JWTTypes.PayloadType | Buffer, callback: JWTTypes.SignCallback): void;
+    sign(payload: JWTTypes.PayloadType | Buffer, options: jwt.SignOptions, callback: JWTTypes.SignCallback): void;
+
+    verify<Decoded extends JWTTypes.PayloadType = any>(token: string, options?: jwt.VerifyOptions): Decoded;
+    verify<Decoded extends JWTTypes.PayloadType = any>(token: string, callback: JWTTypes.VerifyCallback<Decoded>): void;
+    verify<Decoded extends JWTTypes.PayloadType = any>(
+      token: string,
+      options: jwt.VerifyOptions,
+      callback: JWTTypes.VerifyCallback<Decoded>,
+    ): void;
+
+    decode<Decoded extends JWTTypes.PayloadType = any>(token: string, options?: jwt.DecodeOptions): null | Decoded;
   }
 
   interface FastifyInstance {
     jwt: JWT;
   }
 
+  interface FastifyReply<HttpResponse> {
+    jwtSign(payload: JWTTypes.PayloadType | Buffer, options?: jwt.SignOptions): Promise<string>;
+    jwtSign(payload: JWTTypes.PayloadType | Buffer, callback: JWTTypes.SignCallback): void;
+    jwtSign(payload: JWTTypes.PayloadType | Buffer, options: jwt.SignOptions, callback: JWTTypes.SignCallback): void;
+  }
+
   interface FastifyRequest<HttpRequest> {
-    jwtVerify(callback?: jwt.VerifyCallback): Promise<any>;
+    jwtVerify<Decoded extends JWTTypes.PayloadType = any>(options?: jwt.VerifyOptions): Promise<Decoded>;
+    jwtVerify<Decoded extends JWTTypes.PayloadType = any>(callback: JWTTypes.VerifyCallback<Decoded>): void;
+    jwtVerify<Decoded extends JWTTypes.PayloadType = any>(
+      options: jwt.VerifyOptions,
+      callback: JWTTypes.VerifyCallback<Decoded>,
+    ): void;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,11 +4,13 @@ import * as jwt from 'jsonwebtoken';
 
 declare module 'fastify' {
   namespace JWTTypes {
-    type PayloadType = object | string;
+    type SignPayloadType = object | string | Buffer;
+    type VerifyPayloadType = object | string;
+    type DecodePayloadType = object | string;
 
     interface SignCallback extends jwt.SignCallback {}
 
-    interface VerifyCallback<Decoded extends PayloadType> extends jwt.VerifyCallback {
+    interface VerifyCallback<Decoded extends VerifyPayloadType> extends jwt.VerifyCallback {
       (err: jwt.VerifyErrors, decoded: Decoded): void;
     }
   }
@@ -21,19 +23,19 @@ declare module 'fastify' {
     };
     secret: jwt.Secret;
 
-    sign(payload: JWTTypes.PayloadType | Buffer, options?: jwt.SignOptions): string;
-    sign(payload: JWTTypes.PayloadType | Buffer, callback: JWTTypes.SignCallback): void;
-    sign(payload: JWTTypes.PayloadType | Buffer, options: jwt.SignOptions, callback: JWTTypes.SignCallback): void;
+    sign(payload: JWTTypes.SignPayloadType, options?: jwt.SignOptions): string;
+    sign(payload: JWTTypes.SignPayloadType, callback: JWTTypes.SignCallback): void;
+    sign(payload: JWTTypes.SignPayloadType, options: jwt.SignOptions, callback: JWTTypes.SignCallback): void;
 
-    verify<Decoded extends JWTTypes.PayloadType>(token: string, options?: jwt.VerifyOptions): Decoded;
-    verify<Decoded extends JWTTypes.PayloadType>(token: string, callback: JWTTypes.VerifyCallback<Decoded>): void;
-    verify<Decoded extends JWTTypes.PayloadType>(
+    verify<Decoded extends JWTTypes.VerifyPayloadType>(token: string, options?: jwt.VerifyOptions): Decoded;
+    verify<Decoded extends JWTTypes.VerifyPayloadType>(token: string, callback: JWTTypes.VerifyCallback<Decoded>): void;
+    verify<Decoded extends JWTTypes.VerifyPayloadType>(
       token: string,
       options: jwt.VerifyOptions,
       callback: JWTTypes.VerifyCallback<Decoded>,
     ): void;
 
-    decode<Decoded extends JWTTypes.PayloadType>(token: string, options?: jwt.DecodeOptions): null | Decoded;
+    decode<Decoded extends JWTTypes.DecodePayloadType>(token: string, options?: jwt.DecodeOptions): null | Decoded;
   }
 
   interface FastifyInstance {
@@ -41,15 +43,15 @@ declare module 'fastify' {
   }
 
   interface FastifyReply<HttpResponse> {
-    jwtSign(payload: JWTTypes.PayloadType | Buffer, options?: jwt.SignOptions): Promise<string>;
-    jwtSign(payload: JWTTypes.PayloadType | Buffer, callback: JWTTypes.SignCallback): void;
-    jwtSign(payload: JWTTypes.PayloadType | Buffer, options: jwt.SignOptions, callback: JWTTypes.SignCallback): void;
+    jwtSign(payload: JWTTypes.SignPayloadType, options?: jwt.SignOptions): Promise<string>;
+    jwtSign(payload: JWTTypes.SignPayloadType, callback: JWTTypes.SignCallback): void;
+    jwtSign(payload: JWTTypes.SignPayloadType, options: jwt.SignOptions, callback: JWTTypes.SignCallback): void;
   }
 
   interface FastifyRequest<HttpRequest> {
-    jwtVerify<Decoded extends JWTTypes.PayloadType>(options?: jwt.VerifyOptions): Promise<Decoded>;
-    jwtVerify<Decoded extends JWTTypes.PayloadType>(callback: JWTTypes.VerifyCallback<Decoded>): void;
-    jwtVerify<Decoded extends JWTTypes.PayloadType>(
+    jwtVerify<Decoded extends JWTTypes.VerifyPayloadType>(options?: jwt.VerifyOptions): Promise<Decoded>;
+    jwtVerify<Decoded extends JWTTypes.VerifyPayloadType>(callback: JWTTypes.VerifyCallback<Decoded>): void;
+    jwtVerify<Decoded extends JWTTypes.VerifyPayloadType>(
       options: jwt.VerifyOptions,
       callback: JWTTypes.VerifyCallback<Decoded>,
     ): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,47 +1,43 @@
-import * as fastify from "fastify";
-import { IncomingMessage, Server, ServerResponse } from "http";
-import { DecodeOptions, Secret, SignOptions, VerifyCallback, VerifyOptions } from "jsonwebtoken";
+import * as fastify from 'fastify';
+import { IncomingMessage, Server, ServerResponse } from 'http';
+import { DecodeOptions, Secret, SignOptions, VerifyCallback, VerifyOptions } from 'jsonwebtoken';
 
-declare module "fastify"
-{
-    interface Jwt
-    {
-        decode: (token: string, options?: DecodeOptions) => null | { [key: string]: any } | string;
-        options: {
-            /**
-             * decodeOptions
-             */
-            decode: DecodeOptions,
+declare module 'fastify' {
+  interface Jwt {
+    decode: (token: string, options?: DecodeOptions) => null | { [key: string]: any } | string;
+    options: {
+      /**
+       * decodeOptions
+       */
+      decode: DecodeOptions;
 
-            /**
-             * signOptions
-             */
-            sign: SignOptions,
+      /**
+       * signOptions
+       */
+      sign: SignOptions;
 
-            /**
-             * verifyOptions
-             */
-            verify: VerifyOptions,
-        };
-        secret: Secret;
-        sign: (playload: string | Buffer | object, options?: SignOptions, callback?: VerifyCallback) => string;
-        verify: (token: string, options?: VerifyOptions, callback?: VerifyCallback) => Promise<object | string>;
-    }
-    interface FastifyInstance<HttpServer = Server, HttpRequest = IncomingMessage, HttpResponse = ServerResponse>
-    {
-        jwt: Jwt;
-    }
+      /**
+       * verifyOptions
+       */
+      verify: VerifyOptions;
+    };
+    secret: Secret;
+    sign: (playload: string | Buffer | object, options?: SignOptions, callback?: VerifyCallback) => string;
+    verify: (token: string, options?: VerifyOptions, callback?: VerifyCallback) => Promise<object | string>;
+  }
+  interface FastifyInstance<HttpServer = Server, HttpRequest = IncomingMessage, HttpResponse = ServerResponse> {
+    jwt: Jwt;
+  }
 
-    interface FastifyRequest<
-        HttpRequest,
-        Query = DefaultQuery,
-        Params = DefaultParams,
-        Headers = DefaultHeaders,
-        Body = DefaultBody
-        >
-    {
-        jwtVerify(callback?: VerifyCallback): Promise<any>;
-    }
+  interface FastifyRequest<
+    HttpRequest,
+    Query = DefaultQuery,
+    Params = DefaultParams,
+    Headers = DefaultHeaders,
+    Body = DefaultBody
+  > {
+    jwtVerify(callback?: VerifyCallback): Promise<any>;
+  }
 }
 
 declare const fastifyJWT: fastify.Plugin<Server, IncomingMessage, ServerResponse, { secret: Secret }>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,13 @@ declare module 'fastify' {
   }
 }
 
-declare const fastifyJWT: fastify.Plugin<any, any, any, { secret: jwt.Secret }>;
+declare interface FastifyJWTOptions {
+  secret: jwt.Secret;
+  decode?: jwt.DecodeOptions;
+  sign?: jwt.SignOptions;
+  verify?: jwt.VerifyOptions;
+}
+
+declare const fastifyJWT: fastify.Plugin<any, any, any, FastifyJWTOptions>;
 
 export = fastifyJWT;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,45 +1,29 @@
 import * as fastify from 'fastify';
-import { IncomingMessage, Server, ServerResponse } from 'http';
-import { DecodeOptions, Secret, SignOptions, VerifyCallback, VerifyOptions } from 'jsonwebtoken';
+import * as http from 'http';
+import * as jwt from 'jsonwebtoken';
 
 declare module 'fastify' {
-  interface Jwt {
-    decode: (token: string, options?: DecodeOptions) => null | { [key: string]: any } | string;
+  interface JWT {
     options: {
-      /**
-       * decodeOptions
-       */
-      decode: DecodeOptions;
-
-      /**
-       * signOptions
-       */
-      sign: SignOptions;
-
-      /**
-       * verifyOptions
-       */
-      verify: VerifyOptions;
+      decode: jwt.DecodeOptions;
+      sign: jwt.SignOptions;
+      verify: jwt.VerifyOptions;
     };
-    secret: Secret;
-    sign: (playload: string | Buffer | object, options?: SignOptions, callback?: VerifyCallback) => string;
-    verify: (token: string, options?: VerifyOptions, callback?: VerifyCallback) => Promise<object | string>;
-  }
-  interface FastifyInstance<HttpServer = Server, HttpRequest = IncomingMessage, HttpResponse = ServerResponse> {
-    jwt: Jwt;
+    secret: jwt.Secret;
+    sign: (payload: string | Buffer | object, options?: jwt.SignOptions, callback?: jwt.VerifyCallback) => string;
+    verify: (token: string, options?: jwt.VerifyOptions, callback?: jwt.VerifyCallback) => Promise<object | string>;
+    decode: (token: string, options?: jwt.DecodeOptions) => null | { [key: string]: any } | string;
   }
 
-  interface FastifyRequest<
-    HttpRequest,
-    Query = DefaultQuery,
-    Params = DefaultParams,
-    Headers = DefaultHeaders,
-    Body = DefaultBody
-  > {
-    jwtVerify(callback?: VerifyCallback): Promise<any>;
+  interface FastifyInstance {
+    jwt: JWT;
+  }
+
+  interface FastifyRequest<HttpRequest> {
+    jwtVerify(callback?: jwt.VerifyCallback): Promise<any>;
   }
 }
 
-declare const fastifyJWT: fastify.Plugin<Server, IncomingMessage, ServerResponse, { secret: Secret }>;
+declare const fastifyJWT: fastify.Plugin<any, any, any, { secret: jwt.Secret }>;
 
 export = fastifyJWT;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,15 +25,15 @@ declare module 'fastify' {
     sign(payload: JWTTypes.PayloadType | Buffer, callback: JWTTypes.SignCallback): void;
     sign(payload: JWTTypes.PayloadType | Buffer, options: jwt.SignOptions, callback: JWTTypes.SignCallback): void;
 
-    verify<Decoded extends JWTTypes.PayloadType = any>(token: string, options?: jwt.VerifyOptions): Decoded;
-    verify<Decoded extends JWTTypes.PayloadType = any>(token: string, callback: JWTTypes.VerifyCallback<Decoded>): void;
-    verify<Decoded extends JWTTypes.PayloadType = any>(
+    verify<Decoded extends JWTTypes.PayloadType>(token: string, options?: jwt.VerifyOptions): Decoded;
+    verify<Decoded extends JWTTypes.PayloadType>(token: string, callback: JWTTypes.VerifyCallback<Decoded>): void;
+    verify<Decoded extends JWTTypes.PayloadType>(
       token: string,
       options: jwt.VerifyOptions,
       callback: JWTTypes.VerifyCallback<Decoded>,
     ): void;
 
-    decode<Decoded extends JWTTypes.PayloadType = any>(token: string, options?: jwt.DecodeOptions): null | Decoded;
+    decode<Decoded extends JWTTypes.PayloadType>(token: string, options?: jwt.DecodeOptions): null | Decoded;
   }
 
   interface FastifyInstance {
@@ -47,9 +47,9 @@ declare module 'fastify' {
   }
 
   interface FastifyRequest<HttpRequest> {
-    jwtVerify<Decoded extends JWTTypes.PayloadType = any>(options?: jwt.VerifyOptions): Promise<Decoded>;
-    jwtVerify<Decoded extends JWTTypes.PayloadType = any>(callback: JWTTypes.VerifyCallback<Decoded>): void;
-    jwtVerify<Decoded extends JWTTypes.PayloadType = any>(
+    jwtVerify<Decoded extends JWTTypes.PayloadType>(options?: jwt.VerifyOptions): Promise<Decoded>;
+    jwtVerify<Decoded extends JWTTypes.PayloadType>(callback: JWTTypes.VerifyCallback<Decoded>): void;
+    jwtVerify<Decoded extends JWTTypes.PayloadType>(
       options: jwt.VerifyOptions,
       callback: JWTTypes.VerifyCallback<Decoded>,
     ): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,6 @@ declare interface FastifyJWTOptions {
   verify?: jwt.VerifyOptions;
 }
 
-declare const fastifyJWT: fastify.Plugin<any, any, any, FastifyJWTOptions>;
+declare const fastifyJWT: fastify.Plugin<http.Server, http.ClientRequest, http.ServerResponse, FastifyJWTOptions>;
 
 export = fastifyJWT;

--- a/type.test.ts
+++ b/type.test.ts
@@ -3,7 +3,18 @@ import fastifyJwt = require('./index');
 
 const app = fastify();
 
-app.register(fastifyJwt, { secret: "supersecret" });
+app.register(fastifyJwt, {
+    secret: "supersecret",
+    sign: {
+        expiresIn: '1h'
+    },
+    verify: {
+        maxAge: '1h'
+    },
+    decode: {
+        complete: true
+    }
+});
 
 app.addHook("preHandler", async (request, reply) =>
 {


### PR DESCRIPTION
The latest type definitions is invalid to pass `sign` / `verify` / `decode` options.
And, `reply.jwtSign` isn't defined yet.

This PR rewrites type definitions for usability.