### PR TITLE
Add public/private object shape to the FastifyJWTOptions' secret prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ declare module 'fastify' {
 }
 
 declare interface FastifyJWTOptions {
-  secret: jwt.Secret;
+  secret: jwt.Secret | { public: jwt.Secret; private: jwt.Secret };
   decode?: jwt.DecodeOptions;
   sign?: jwt.SignOptions;
   verify?: jwt.VerifyOptions;

--- a/type.test.ts
+++ b/type.test.ts
@@ -4,7 +4,7 @@ import fastifyJwt = require('./index');
 const app = fastify();
 
 app.register(fastifyJwt, {
-    secret: "supersecret",
+    secret: process.env.usePublicPrivateKeys ? "supersecret" : { public: 'publicKey', private: 'privateKey' },
     sign: {
         expiresIn: '1h'
     },


### PR DESCRIPTION
Since the doc states that it's allowed to provide a public/private keys,
the typescript definitions should also support that.

Closes #60 