### PR TITLE
[Feature] allow custom HTTP response messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ fastify.log.info(`Decoded JWT: ${decoded}`)
 ```
 
 ### fastify.jwt.options
-For your convenience, the `decode`, `sign` and `verify` options you specify during `.register` are made available via `fastify.jwt.options` that will return an object  `{ decode, sign, verify }` containing your options.
+For your convenience, the `decode`, `sign`, `verify` and `messages` options you specify during `.register` are made available via `fastify.jwt.options` that will return an object  `{ decode, sign, verify, messages }` containing your options.
 
 #### Example
 ```js
@@ -331,6 +331,29 @@ fastify.listen(3000, err => {
 * `clockTolerance`: number of seconds to tolerate when checking the `nbf` and `exp` claims, to deal with small clock differences among different servers
 * `maxAge`: the maximum allowed age for tokens to still be valid. It is expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). Eg: `1000`, `"2 days"`, `"10h"`, `"7d"`. A numeric value is interpreted as a seconds count. If you use a string be sure you provide the time units (days, hours, etc), otherwise milliseconds unit is used by default (`"120"` is equal to `"120ms"`).
 * `clockTimestamp`: the time in seconds that should be used as the current time for all necessary comparisons.
+
+#### messages options
+
+For your onvenience, you can override the default HTTP response messages sent when an unauthorized or bad request error occurs. You can choose the specific messages to override and the rest will fallback to the default messages. The object must be in the format specified in the example below.
+
+#### Example
+
+```js
+const fastify = require('fastify')
+
+const myCustomMessages = {
+  badRequestErrorMessage: 'Format is Authorization: Bearer [token]',
+  noAuthorizationInHeaderMessage: 'Autorization header is missing!',
+  authorizationTokenExpiredMessage: 'Authorization token expired',
+  // for the below message you can pass a function as shown or a string
+  authorizationTokenInvalid: (err) => `Authorization token is invalid: ${err.message}`
+}
+
+fastify.register(require('fastify-jwt'), {
+  secret: 'supersecret',
+  messages: myCustomMessages
+})
+```
 
 ### fastify.jwt.secret
 For your convenience, the `secret` you specify during `.register` is made available via `fastify.jwt.secret`. `request.jwtVerify()` and `reply.jwtSign()` will wrap non-function secrets in a callback function. `request.jwtVerify()` and `reply.jwtSign()` use an asynchronous waterfall method to retrieve your secret. It's recommended that your use these methods if your `secret` method is asynchronous.

--- a/README.md
+++ b/README.md
@@ -345,8 +345,10 @@ const myCustomMessages = {
   badRequestErrorMessage: 'Format is Authorization: Bearer [token]',
   noAuthorizationInHeaderMessage: 'Autorization header is missing!',
   authorizationTokenExpiredMessage: 'Authorization token expired',
-  // for the below message you can pass a function as shown or a string
-  authorizationTokenInvalid: (err) => `Authorization token is invalid: ${err.message}`
+  // for the below message you can pass a sync function that must return a string as shown or a string
+  authorizationTokenInvalid: (err) => {
+    return `Authorization token is invalid: ${err.message}`
+  }
 }
 
 fastify.register(require('fastify-jwt'), {

--- a/jwt.js
+++ b/jwt.js
@@ -53,7 +53,7 @@ function fastifyJwt (fastify, options, next) {
   const decodeOptions = options.decode || {}
   const signOptions = options.sign || {}
   const verifyOptions = options.verify || {}
-  const messagesOptions = Object.assign(messages, options.messages)
+  const messagesOptions = Object.assign({}, messages, options.messages)
 
   if (
     signOptions &&


### PR DESCRIPTION
Custom messages for HTTP responses to be passed as additional options. User can choose custom messages the rest will fallback to default. As discussed at #62.

#### Example

```js
const fastify = require('fastify')
const myCustomMessages = {
  badRequestErrorMessage: 'Bad Request: Header Missing',
  // noAuthorizationInHeaderMessage and authorizationTokenExpiredMessage will fallback to default
  // for the below message you can pass either a function as shown or a string
  authorizationTokenInvalid: (err) => `error: ${err.message}`
}
fastify.register(require('fastify-jwt'), {
  secret: 'supersecret',
  messages: myCustomMessages
})
```