### PR TITLE
docs(README): fix example with send error

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ fastify.addHook("onRequest", async (request, reply) => {
   try {
     await request.jwtVerify()
   } catch (err) {
-    reply.send(err)
+    reply.send(err.message)
   }
 })
 ```
@@ -70,7 +70,7 @@ module.exports = fp(async function(fastify, opts) {
     try {
       await request.jwtVerify()
     } catch (err) {
-      reply.send(err)
+      reply.send(err.message)
     }
   })
 })


### PR DESCRIPTION
The examples send an error based on a `http-errors` (Unauthorized, BadRequest), and Fastify not recognize it. So, I think that sends just a message like a plain/text sounds better.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
