### PR TITLE
Add link to fastify-auth0-verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ module.exports = async function(fastify, opts) {
 
 Make sure that you also check [fastify-auth](https://github.com/fastify/fastify-auth) plugin for composing more complex strategies.
 
+### Auth0 tokens verification
+
+If you need to verify Auth0 issued HS256 or RS256 JWT tokens, you can use [fastify-auth0-verify](https://github.com/nearform/fastify-auth0-verify), which is based on top of this module.
+
 ## API Spec
 
 ### fastify-jwt


### PR DESCRIPTION
Hi!
I've created this plugin based on top of fastify-jwt that enables verification of Auth0 issued tokens with HS256 or RS256.
Hope this helps!

Fixes #72 

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)