### PR TITLE
Error: Change `reply` to `token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In this object `{ private, public }` the `private` key is a string, buffer or ob
 
 In this object `{ private, public }` the `public` key is a string or buffer containing either the secret for HMAC algorithms, or the PEM encoded public key for RSA and ECDSA.
 
-Function based `secret` is supported by the `request.jwtVerify()` and `reply.jwtSign()` methods and is called with `request`, `reply`, and `callback` parameters.
+Function based `secret` is supported by the `request.jwtVerify()` and `reply.jwtSign()` methods and is called with `request`, `token`, and `callback` parameters.
 #### Example
 ```js
 const { readFileSync } = require('fs')
@@ -118,7 +118,7 @@ const jwt = require('fastify-jwt')
 fastify.register(jwt, { secret: 'supersecret' })
 // secret as a function
 fastify.register(jwt, {
-  secret: function (request, reply, callback) {
+  secret: function (request, token, callback) {
     // do something
     callback(null, 'supersecret')
   }


### PR DESCRIPTION
There seems to be an error in the README. When `secret` is a function, the second parameter is a decoded token, not `reply`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
