### PR TITLE
feature: add cookie option to req verify decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ fastify.listen(3000, err => {
 
 In some situations you may want to store a token in a cookie. This allows you to drastically reduce the attack surface of XSS on your webapp with the [`httpOnly`](https://wiki.owasp.org/index.php/HttpOnly) and `secure` flags. Cookies can be susceptible to CSRF. You can mitigate this by either setting the [`sameSite`](https://www.owasp.org/index.php/SameSite) flag to `strict`, or by using a CSRF library such as [fastify-csrf](https://www.npmjs.com/package/fastify-csrf).
 
-**Note:** This plugin will look for a decorate request with the `cookies` property. `fastify-cookie` supports this feature, and therefore you should use it when using the cookie feature. The plugin will fallback to looking for the token in the authorization header if either of the following happens (even if the cookie option is enabled):
+**Note:** This plugin will look for a decorated request with the `cookies` property. `fastify-cookie` supports this feature, and therefore you should use it when using the cookie feature. The plugin will fallback to looking for the token in the authorization header if either of the following happens (even if the cookie option is enabled):
 
 - The request has both the authorization and cookie header
 - Cookie is empty, authorization header is present
@@ -447,7 +447,7 @@ fastify.register(require('fastify-jwt'), {
 For your convenience, the `secret` you specify during `.register` is made available via `fastify.jwt.secret`. `request.jwtVerify()` and `reply.jwtSign()` will wrap non-function secrets in a callback function. `request.jwtVerify()` and `reply.jwtSign()` use an asynchronous waterfall method to retrieve your secret. It's recommended that your use these methods if your `secret` method is asynchronous.
 
 ### fastify.jwt.cookie
-For your convenience, `request.jwtVerify()` will look for the token in the cookies property of the decorated request. you must specify `cookieName`. Refere to the [cookie example](https://github.com/fastify/fastify-jwt#example-using-cookie) to see sample usage and important caveats.
+For your convenience, `request.jwtVerify()` will look for the token in the cookies property of the decorated request. You must specify `cookieName`. Refer to the [cookie example](https://github.com/fastify/fastify-jwt#example-using-cookie) to see sample usage and important caveats.
 
 ### reply.jwtSign(payload, [options,] callback)
 ### request.jwtVerify([options,] callback)

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ fastify.listen(3000, err => {
 
 #### Example using cookie
 
-In some situations you may want to store a token in a cookie. This allows you to drastically reduce the attack surface of XSS on your webapp with the [`httpOnly`](https://wiki.owasp.org/index.php/HttpOnly) and `secure` flags. Cookies can be susceptible to CSRF. You can mitigate this by either setting the [`sameSite`](https://www.owasp.org/index.php/SameSite) flag to `strict`, or by using a CSRF library such as [fastify-csrf](https://www.npmjs.com/package/fastify-csrf).
+In some situations you may want to store a token in a cookie. This allows you to drastically reduce the attack surface of XSS on your webapp with the [`httpOnly`](https://wiki.owasp.org/index.php/HttpOnly) and `secure` flags. Cookies can be susceptible to CSRF. You can mitigate this by either setting the [`sameSite`](https://www.owasp.org/index.php/SameSite) flag to `strict`, or by using a CSRF library such as [`fastify-csrf`](https://www.npmjs.com/package/fastify-csrf).
 
-**Note:** This plugin will look for a decorated request with the `cookies` property. `fastify-cookie` supports this feature, and therefore you should use it when using the cookie feature. The plugin will fallback to looking for the token in the authorization header if either of the following happens (even if the cookie option is enabled):
+**Note:** This plugin will look for a decorated request with the `cookies` property. [`fastify-cookie`](https://www.npmjs.com/package/fastify-cookie) supports this feature, and therefore you should use it when using the cookie feature. The plugin will fallback to looking for the token in the authorization header if either of the following happens (even if the cookie option is enabled):
 
 - The request has both the authorization and cookie header
 - Cookie is empty, authorization header is present

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ fastify.listen(3000, err => {
 
 #### Example using cookie
 
-In some situations you may want to store a token in a cookie. This allows you to drastically reduce the attack surface of XSS on your webapp with the `[httpOnly](https://wiki.owasp.org/index.php/HttpOnly)` and `secure` flags. Cookies can be susceptible to CSRF. You can mitigate this by either setting the `[sameSite](https://www.owasp.org/index.php/SameSite)` flag to `strict`, or by using a CSRF library such as [fastify-csrf](https://www.npmjs.com/package/fastify-csrf).
+In some situations you may want to store a token in a cookie. This allows you to drastically reduce the attack surface of XSS on your webapp with the [`httpOnly`](https://wiki.owasp.org/index.php/HttpOnly) and `secure` flags. Cookies can be susceptible to CSRF. You can mitigate this by either setting the [`sameSite`](https://www.owasp.org/index.php/SameSite) flag to `strict`, or by using a CSRF library such as [fastify-csrf](https://www.npmjs.com/package/fastify-csrf).
 
 **Note:** This plugin will look for a decorate request with the `cookies` property. `fastify-cookie` supports this feature, and therefore you should use it when using the cookie feature. The plugin will fallback to looking for the token in the authorization header if either of the following happens (even if the cookie option is enabled):
 

--- a/README.md
+++ b/README.md
@@ -220,70 +220,49 @@ fastify.listen(3000, err => {
 
 #### Example using cookie
 
-Storing JWT in Cookie mean that your app maybe vunerable to XSS attack and must be protected with CSRF token,
-consider that as a best practice. but storing JWT on cookies makes your REST API arent Stateless anymore, choose what fit for you.
-You can use [crsf](https://www.npmjs.com/package/csrf) or other library that may suit your need.
+In some situations you may want to store a token in a cookie. This allows you to drastically reduce the attack surface of XSS on your webapp with the `[httpOnly](https://wiki.owasp.org/index.php/HttpOnly)` and `secure` flags. Cookies can be susceptible to CSRF. You can mitigate this by either setting the `[sameSite](https://www.owasp.org/index.php/SameSite)` flag to `strict`, or by using a CSRF library such as [fastify-csrf](https://www.npmjs.com/package/fastify-csrf).
+
+**Note:** This plugin will look for a decorate request with the `cookies` property. `fastify-cookie` supports this feature, and therefore you should use it when using the cookie feature. The plugin will fallback to looking for the token in the authorization header if either of the following happens (even if the cookie option is enabled):
+
+- The request has both the authorization and cookie header
+- Cookie is empty, authorization header is present
 
 ```js
-const { readFileSync } = require('fs')
-const path = require('path')
 const fastify = require('fastify')()
 const jwt = require('fastify-jwt')
-const Redis = require('ioredis')
 
-// docker run -p 6379:6379 --name redis-test redis
-const redis = new Redis({ port: 6379, host: '127.0.0.1' })
-const abcache = require('abstract-cache')({
-  useAwait: false,
-  driver: {
-    name: 'abstract-cache-redis', // Must be installed via `npm install`
-    options: { client: redis }
+fastify.register(jwt, {
+  secret: 'foobar'
+  cookie: { 
+    cookieName: 'token'
   }
 })
 
-fastify.register(jwt, {
-  secret: {
-    private: {
-      key: readFileSync(`${path.join(__dirname, 'certs')}/private.pem`),
-      passphrase: 'super secret passphrase'
-    },
-    public: readFileSync(`${path.join(__dirname, 'certs')}/public.pem`)
-  },
-  sign: { algorithm: 'ES256' }
-})
-
 fastify
-  .register(require('fastify-redis'), { client: redis })
   .register(require('fastify-cookie'))
-  .register(require('fastify-caching'), { cache: abcache })
-  .register(require('fastify-server-session'), {
-    secretKey: 'some-secret-password-at-least-32-characters-long',
-    sessionMaxAge: 900000 // 15 minutes in milliseconds
-  })
 
 fastify.get('/cookies', async (request, reply) => {
   const token = await reply.jwtSign({
     name: 'foo',
     role: ['admin', 'spy']
-    // you may registering your csrf here
   })
 
   reply
     .setCookie('token', token, {
-      domain: '.domain',
-      path: '/'
+      domain: 'your.domain',
+      path: '/',
+      secure: true, // send cookie over HTTPS only
+      httpOnly: true,
+      sameSite: true // alternative CSRF protection
     })
     .code(200)
-    .send('Cookies are send!')
+    .send('Cookie sent')
 })
 
-fastify.get('/verifyCookies', async (request, reply) => {
-  try {
-    const verified = await fastify.jwt.verify(request.cookies.token)
-    reply.code(200).send(verified) // same as above, contain decoded tokens
-  } catch (err) {
-    reply.code(401).send(err)
-  }
+fastify.addHook('onRequest', (request) => request.jwtVerify())
+
+fastify.get('/verifycookie', (request, reply) => {
+  reply.send({ code: 'OK', message: 'it works!' })
 })
 
 fastify.listen(3000, err => {
@@ -466,6 +445,9 @@ fastify.register(require('fastify-jwt'), {
 
 ### fastify.jwt.secret
 For your convenience, the `secret` you specify during `.register` is made available via `fastify.jwt.secret`. `request.jwtVerify()` and `reply.jwtSign()` will wrap non-function secrets in a callback function. `request.jwtVerify()` and `reply.jwtSign()` use an asynchronous waterfall method to retrieve your secret. It's recommended that your use these methods if your `secret` method is asynchronous.
+
+### fastify.jwt.cookie
+For your convenience, `request.jwtVerify()` will look for the token in the cookies property of the decorated request. you must specify `cookieName`. Refere to the [cookie example](https://github.com/fastify/fastify-jwt#example-using-cookie) to see sample usage and important caveats.
 
 ### reply.jwtSign(payload, [options,] callback)
 ### request.jwtVerify([options,] callback)

--- a/jwt.js
+++ b/jwt.js
@@ -204,7 +204,7 @@ function fastifyJwt (fastify, options, next) {
       return next(new Unauthorized(messagesOptions.noAuthorizationInCookieMessage))
     }
 
-    if (!options && request.headers && request.headers.authorization) {
+    if (request.headers && request.headers.authorization) {
       const parts = request.headers.authorization.split(' ')
       if (parts.length === 2) {
         const scheme = parts[0]
@@ -216,7 +216,7 @@ function fastifyJwt (fastify, options, next) {
       } else {
         return next(new BadRequest(messagesOptions.badRequestErrorMessage))
       }
-    } else if (!options && !request.headers.authorization) {
+    } else if (!options.cookie) {
       return next(new Unauthorized(messagesOptions.noAuthorizationInHeaderMessage))
     }
 

--- a/jwt.js
+++ b/jwt.js
@@ -53,6 +53,8 @@ function fastifyJwt (fastify, options, next) {
   if (typeof secretCallbackSign !== 'function') { secretCallbackSign = wrapStaticSecretInCallback(secretCallbackSign) }
   if (typeof secretCallbackVerify !== 'function') { secretCallbackVerify = wrapStaticSecretInCallback(secretCallbackVerify) }
 
+  const cookie = options.cookie
+
   const decodeOptions = options.decode || {}
   const signOptions = options.sign || {}
   const verifyOptions = options.verify || {}
@@ -85,6 +87,7 @@ function fastifyJwt (fastify, options, next) {
       verify: verifyOptions,
       messages: messagesOptions
     },
+    cookie: cookie,
     secret: secret,
     sign: sign,
     verify: verify
@@ -198,9 +201,9 @@ function fastifyJwt (fastify, options, next) {
     }
 
     let token
-    if (options.cookie && request.cookies[options.cookieName]) {
-      token = request.cookies[options.cookieName]
-    } else if (options.cookie && !request.cookies[options.cookieName]) {
+    if (cookie && request.cookies[cookie.cookieName]) {
+      token = request.cookies[cookie.cookieName]
+    } else if (cookie && !request.cookies[cookie.cookieName]) {
       return next(new Unauthorized(messagesOptions.noAuthorizationInCookieMessage))
     }
 
@@ -216,7 +219,7 @@ function fastifyJwt (fastify, options, next) {
       } else {
         return next(new BadRequest(messagesOptions.badRequestErrorMessage))
       }
-    } else if (!options.cookie) {
+    } else if (!cookie) {
       return next(new Unauthorized(messagesOptions.noAuthorizationInHeaderMessage))
     }
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "fastify": "^2.0.0",
+    "fastify-cookie": "^3.5.0",
     "standard": "^14.0.2",
     "tap": "^12.6.5",
     "typescript": "^3.2.2"

--- a/test.js
+++ b/test.js
@@ -1585,7 +1585,7 @@ test('token in cookie', function (t) {
   t.plan(2)
 
   const fastify = Fastify()
-  fastify.register(jwt, { secret: 'test' })
+  fastify.register(jwt, { secret: 'test', cookie: { cookieName: 'jwt' } })
   fastify.register(require('fastify-cookie'))
 
   fastify.post('/sign', function (request, reply) {
@@ -1596,10 +1596,7 @@ test('token in cookie', function (t) {
   })
 
   fastify.get('/verify', function (request, reply) {
-    request.jwtVerify({
-      cookie: true,
-      cookieName: 'jwt'
-    })
+    request.jwtVerify()
       .then(function (decodedToken) {
         return reply.send(decodedToken)
       })

--- a/test.js
+++ b/test.js
@@ -1748,7 +1748,7 @@ test('token in cookie, with fastify-cookie parsing', function (t) {
   })
 })
 
-test('token in cookie, with no cookie parsing', function (t) {
+test('token in cookie, without fastify-cookie parsing', function (t) {
   t.plan(2)
 
   const fastify = Fastify()

--- a/test.js
+++ b/test.js
@@ -1600,9 +1600,6 @@ test('token in cookie, with fastify-cookie parsing', function (t) {
       .then(function (decodedToken) {
         return reply.send(decodedToken)
       })
-      .catch(function (error) {
-        return reply.send(error)
-      })
   })
 
   t.test('token present in cookie', function (t) {
@@ -1615,7 +1612,7 @@ test('token in cookie, with fastify-cookie parsing', function (t) {
       const token = JSON.parse(signResponse.payload).token
       t.ok(token)
 
-      fastify.inject({
+      return fastify.inject({
         method: 'get',
         url: '/verify',
         cookies: {
@@ -1633,7 +1630,7 @@ test('token in cookie, with fastify-cookie parsing', function (t) {
     fastify.inject({
       method: 'get',
       url: '/verify',
-      cookies: { }
+      cookies: {}
     }).then(function (verifyResponse) {
       const error = JSON.parse(verifyResponse.payload)
       t.is(error.message, 'No Authorization was found in request.cookies')
@@ -1651,7 +1648,7 @@ test('token in cookie, with fastify-cookie parsing', function (t) {
       const token = JSON.parse(signResponse.payload).token
       t.ok(token)
 
-      fastify.inject({
+      return fastify.inject({
         method: 'get',
         url: '/verify',
         cookies: {
@@ -1677,7 +1674,7 @@ test('token in cookie, with fastify-cookie parsing', function (t) {
       const token = JSON.parse(signResponse.payload).token
       t.ok(token)
 
-      fastify.inject({
+      return fastify.inject({
         method: 'get',
         url: '/verify',
         cookies: {
@@ -1703,7 +1700,7 @@ test('token in cookie, with fastify-cookie parsing', function (t) {
       const token = JSON.parse(signResponse.payload).token
       t.ok(token)
 
-      fastify.inject({
+      return fastify.inject({
         method: 'get',
         url: '/verify',
         cookies: {
@@ -1730,7 +1727,7 @@ test('token in cookie, with fastify-cookie parsing', function (t) {
       const token = JSON.parse(signResponse.payload).token
       t.ok(token)
 
-      fastify.inject({
+      return fastify.inject({
         method: 'get',
         url: '/verify',
         cookies: {
@@ -1766,9 +1763,6 @@ test('token in cookie, without fastify-cookie parsing', function (t) {
       .then(function (decodedToken) {
         return reply.send(decodedToken)
       })
-      .catch(function (error) {
-        return reply.send(error)
-      })
   })
 
   t.test('token present in cookie, but unparsed', function (t) {
@@ -1781,7 +1775,7 @@ test('token in cookie, without fastify-cookie parsing', function (t) {
       const token = JSON.parse(signResponse.payload).token
       t.ok(token)
 
-      fastify.inject({
+      return fastify.inject({
         method: 'get',
         url: '/verify',
         cookies: {
@@ -1805,7 +1799,7 @@ test('token in cookie, without fastify-cookie parsing', function (t) {
       const token = JSON.parse(signResponse.payload).token
       t.ok(token)
 
-      fastify.inject({
+      return fastify.inject({
         method: 'get',
         url: '/verify',
         cookies: {

--- a/test.js
+++ b/test.js
@@ -1581,8 +1581,8 @@ test('errors', function (t) {
     })
 })
 
-test('token in cookie', function (t) {
-  t.plan(2)
+test('token in cookie, with fastify-cookie parsing', function (t) {
+  t.plan(6)
 
   const fastify = Fastify()
   fastify.register(jwt, { secret: 'test', cookie: { cookieName: 'jwt' } })
@@ -1641,10 +1641,220 @@ test('token in cookie', function (t) {
           method: 'get',
           url: '/verify',
           cookies: { }
-        }).then(function (response) {
-          const error = JSON.parse(response.payload)
+        }).then(function (verifyResponse) {
+          const error = JSON.parse(verifyResponse.payload)
           t.is(error.message, 'No Authorization was found in request.cookies')
-          t.is(response.statusCode, 401)
+          t.is(error.statusCode, 401)
+        }).catch(function (error) {
+          t.fail(error)
+        })
+      })
+
+      t.test('both authorization header and cookie present, both valid', function (t) {
+        t.plan(2)
+        fastify.inject({
+          method: 'post',
+          url: '/sign',
+          payload: { foo: 'bar' }
+        }).then(function (signResponse) {
+          const token = JSON.parse(signResponse.payload).token
+          t.ok(token)
+
+          fastify.inject({
+            method: 'get',
+            url: '/verify',
+            cookies: {
+              jwt: token
+            },
+            headers: {
+              authorization: `Bearer ${token}`
+            }
+          }).then(function (verifyResponse) {
+            const decodedToken = JSON.parse(verifyResponse.payload)
+            t.is(decodedToken.foo, 'bar')
+          }).catch(function (error) {
+            t.fail(error)
+          })
+        }).catch(function (error) {
+          t.fail(error)
+        })
+      })
+
+      t.test('both authorization and cookie headers present, cookie token value empty (header fallback)', function (t) {
+        t.plan(2)
+        fastify.inject({
+          method: 'post',
+          url: '/sign',
+          payload: { foo: 'bar' }
+        }).then(function (signResponse) {
+          const token = JSON.parse(signResponse.payload).token
+          t.ok(token)
+
+          fastify.inject({
+            method: 'get',
+            url: '/verify',
+            cookies: {
+              jwt: ''
+            },
+            headers: {
+              authorization: `Bearer ${token}`
+            }
+          }).then(function (verifyResponse) {
+            const decodedToken = JSON.parse(verifyResponse.payload)
+            t.is(decodedToken.foo, 'bar')
+          }).catch(function (error) {
+            t.fail(error)
+          })
+        }).catch(function (error) {
+          t.fail(error)
+        })
+      })
+
+      t.test('both authorization and cookie headers present, both values empty', function (t) {
+        t.plan(3)
+        fastify.inject({
+          method: 'post',
+          url: '/sign',
+          payload: { foo: 'bar' }
+        }).then(function (signResponse) {
+          const token = JSON.parse(signResponse.payload).token
+          t.ok(token)
+
+          fastify.inject({
+            method: 'get',
+            url: '/verify',
+            cookies: {
+              jwt: ''
+            },
+            headers: {
+              authorization: ''
+            }
+          }).then(function (verifyResponse) {
+            const error = JSON.parse(verifyResponse.payload)
+            t.is(error.message, 'No Authorization was found in request.cookies')
+            t.is(error.statusCode, 401)
+          }).catch(function (error) {
+            t.fail(error)
+          })
+        }).catch(function (error) {
+          t.fail(error)
+        })
+      })
+
+      t.test('both authorization and cookie headers present, header malformed', function (t) {
+        t.plan(3)
+        fastify.inject({
+          method: 'post',
+          url: '/sign',
+          payload: { foo: 'bar' }
+        }).then(function (signResponse) {
+          const token = JSON.parse(signResponse.payload).token
+          t.ok(token)
+
+          fastify.inject({
+            method: 'get',
+            url: '/verify',
+            cookies: {
+              jwt: token
+            },
+            headers: {
+              authorization: 'BearerX'
+            }
+          }).then(function (verifyResponse) {
+            const error = JSON.parse(verifyResponse.payload)
+            t.is(error.message, 'Format is Authorization: Bearer [token]')
+            t.is(error.statusCode, 400)
+          }).catch(function (error) {
+            t.fail(error)
+          })
+        }).catch(function (error) {
+          t.fail(error)
+        })
+      })
+    })
+})
+
+test('token in cookie, with no cookie parsing', function (t) {
+  t.plan(2)
+
+  const fastify = Fastify()
+  fastify.register(jwt, { secret: 'test', cookie: { cookieName: 'jwt' } })
+
+  fastify.post('/sign', function (request, reply) {
+    reply.jwtSign(request.body)
+      .then(function (token) {
+        return reply.send({ token })
+      })
+  })
+
+  fastify.get('/verify', function (request, reply) {
+    request.jwtVerify()
+      .then(function (decodedToken) {
+        return reply.send(decodedToken)
+      })
+      .catch(function (error) {
+        return reply.send(error)
+      })
+  })
+
+  fastify
+    .ready()
+    .then(function () {
+      t.test('token present in cookie, but unparsed', function (t) {
+        t.plan(3)
+        fastify.inject({
+          method: 'post',
+          url: '/sign',
+          payload: { foo: 'bar' }
+        }).then(function (signResponse) {
+          const token = JSON.parse(signResponse.payload).token
+          t.ok(token)
+
+          fastify.inject({
+            method: 'get',
+            url: '/verify',
+            cookies: {
+              jwt: token
+            }
+          }).then(function (verifyResponse) {
+            const error = JSON.parse(verifyResponse.payload)
+            t.is(error.message, 'Cookie could not be parsed in request')
+            t.is(error.statusCode, 400)
+          }).catch(function (error) {
+            t.fail(error)
+          })
+        }).catch(function (error) {
+          t.fail(error)
+        })
+      })
+
+      t.test('both authorization and cookie headers present, cookie uparsed (header fallback)', function (t) {
+        t.plan(2)
+        fastify.inject({
+          method: 'post',
+          url: '/sign',
+          payload: { foo: 'bar' }
+        }).then(function (signResponse) {
+          const token = JSON.parse(signResponse.payload).token
+          t.ok(token)
+
+          fastify.inject({
+            method: 'get',
+            url: '/verify',
+            cookies: {
+              jwt: token
+            },
+            headers: {
+              authorization: `Bearer ${token}`
+            }
+          }).then(function (verifyResponse) {
+            const decodedToken = JSON.parse(verifyResponse.payload)
+            t.is(decodedToken.foo, 'bar')
+          }).catch(function (error) {
+            t.fail(error)
+          })
+        }).catch(function (error) {
+          t.fail(error)
         })
       })
     })


### PR DESCRIPTION
- refs:  fastify/fastify-jwt#80

#### Description

This aims to add cookie support to the current `req.jwtVerify` decorator. Generally JSON web tokens are assumed (and correctly so) to be included in the `Authorization` header as part of bearer authentication. JWT's are also meant to be short term since they are stateless, however in a lot of situations one would want to persist the token on the front-end so that they can attach the token to every request to the backend.

The frontend will then persist the token in usually in localstorage or some state store (redux/vuex). However for best security practices, one would want to store the token in a properly configured cookie (httpOnly + sameSite + secure) which will prevent any `js` from reading the token reducing the attack surface.

This feature will **optionally** allow users to check for the token in a cookie. Its not a breaking change.

#### Usage
```
# sample cookie
Cookie: token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c...............
```
~req.jwtVerify({ cookie: true, cookieName: '' })~

```js
fastify.register(jwt, { secret: 'test', cookie: { cookieName: 'jwt' } })
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
