### PR TITLE
Two first examples in the README is not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm i fastify-jwt --save
 Register as a plugin. This will decorate your `fastify` instance with the standard [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken) methods `decode`, `sign`, and `verify`; refer to their documentation to find how to use the utilities. It will also register `request.jwtVerify` and `reply.jwtSign`. You must pass a `secret` when registering the plugin.
 
 ```js
-const fastify = require('fastify')
+const fastify = require('fastify')()
 fastify.register(require('fastify-jwt'), {
   secret: 'supersecret'
 })
@@ -32,7 +32,7 @@ fastify.listen(3000, err => {
 For verifying & accessing the decoded token inside your services, you can use a global `onRequest` hook to define the verification process like so:
 
 ```js
-const fastify = require('fastify')
+const fastify = require('fastify')()
 fastify.register(require('fastify-jwt'), {
   secret: 'supersecret'
 })


### PR DESCRIPTION
The two first examples in the README has a small error in it causing them to throw if they are cut and pasted:

```sh
fastify.register(require('fastify-jwt'), {
        ^
TypeError: fastify.register is not a function
```
This fixes it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
