### PR TITLE
Add ability to specify the token location in request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ fastify.listen(3000, err => {
 * `clockTolerance`: number of seconds to tolerate when checking the `nbf` and `exp` claims, to deal with small clock differences among different servers
 * `maxAge`: the maximum allowed age for tokens to still be valid. It is expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). Eg: `1000`, `"2 days"`, `"10h"`, `"7d"`. A numeric value is interpreted as a seconds count. If you use a string be sure you provide the time units (days, hours, etc), otherwise milliseconds unit is used by default (`"120"` is equal to `"120ms"`).
 * `clockTimestamp`: the time in seconds that should be used as the current time for all necessary comparisons.
+* `extractToken(request): token`: Callback function allowing to use custom logic to extract the JWT token from the request.
 
 #### messages options
 

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -7,7 +7,7 @@ declare module 'fastify' {
     type VerifyPayloadType = object | string;
     type DecodePayloadType = object | string;
 
-    interface SignCallback extends jwt.SignCallback {}
+    interface SignCallback extends jwt.SignCallback { }
 
     interface VerifyCallback<Decoded extends VerifyPayloadType> extends jwt.VerifyCallback {
       (err: jwt.VerifyErrors, decoded: Decoded): void;
@@ -63,8 +63,8 @@ declare namespace fastifyJWT {
     secret: jwt.Secret | { public: jwt.Secret; private: jwt.Secret };
     decode?: jwt.DecodeOptions;
     sign?: jwt.SignOptions;
-    verify?: jwt.VerifyOptions;
-    cookie?: { 
+    verify?: jwt.VerifyOptions & { extractToken?: (request: fastify.FastifyRequest) => string | void; };
+    cookie?: {
       cookieName: string;
     };
     messages?: {
@@ -74,7 +74,7 @@ declare namespace fastifyJWT {
       authorizationTokenInvalid?: ((err: Error) => string) | string;
       authorizationTokenUntrusted?: string;
     }
-    trusted?: (request: fastify.FastifyRequest, decodedToken: {[k: string]: any}) => boolean | Promise<boolean> | fastify.JWTTypes.SignPayloadType | Promise<fastify.JWTTypes.SignPayloadType>
+    trusted?: (request: fastify.FastifyRequest, decodedToken: { [k: string]: any }) => boolean | Promise<boolean> | fastify.JWTTypes.SignPayloadType | Promise<fastify.JWTTypes.SignPayloadType>
   }
 
 }

--- a/jwt.js
+++ b/jwt.js
@@ -66,7 +66,7 @@ function fastifyJwt (fastify, options, next) {
     signOptions.algorithm &&
     signOptions.algorithm.includes('RS') &&
     (typeof secret === 'string' ||
-    secret instanceof Buffer)
+      secret instanceof Buffer)
   ) {
     return next(new Error('RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret'))
   }
@@ -75,7 +75,7 @@ function fastifyJwt (fastify, options, next) {
     signOptions.algorithm &&
     signOptions.algorithm.includes('ES') &&
     (typeof secret === 'string' ||
-    secret instanceof Buffer)
+      secret instanceof Buffer)
   ) {
     return next(new Error('ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret'))
   }
@@ -202,7 +202,13 @@ function fastifyJwt (fastify, options, next) {
     }
 
     let token
-    if (request.headers && request.headers.authorization) {
+    const extractToken = options.extractToken
+    if (extractToken) {
+      token = extractToken(request)
+      if (!token) {
+        return next(new BadRequest(messagesOptions.badRequestErrorMessage))
+      }
+    } else if (request.headers && request.headers.authorization) {
       const parts = request.headers.authorization.split(' ')
       if (parts.length === 2) {
         const scheme = parts[0]

--- a/jwt.test-d.ts
+++ b/jwt.test-d.ts
@@ -13,7 +13,8 @@ app.register(fastifyJwt, {
         cookieName: 'jwt'
     },
     verify: {
-        maxAge: '1h'
+        maxAge: '1h',
+        extractToken: (request) => 'token'
     },
     decode: {
         complete: true
@@ -24,8 +25,8 @@ app.register(fastifyJwt, {
         authorizationTokenExpiredMessage: 'Token Expired',
         authorizationTokenInvalid: (err) => `${err.message}`,
         authorizationTokenUntrusted: 'Token untrusted'
-   },
-   trusted: () => true,
+    },
+    trusted: () => true,
 });
 
 // expect jwt and its subsequent methods have merged with the fastify instance
@@ -34,25 +35,21 @@ expectAssignable<Function>(app.jwt.sign)
 expectAssignable<Function>(app.jwt.verify)
 expectAssignable<Function>(app.jwt.decode)
 
-app.addHook("preHandler", async (request, reply) =>
-{
+app.addHook("preHandler", async (request, reply) => {
     // assert request and reply specific interface merges
     expectAssignable<Function>(request.jwtVerify)
     expectAssignable<object | string | Buffer>(request.user)
     expectAssignable<Function>(reply.jwtSign)
 
-    try
-    {
+    try {
         await request.jwtVerify();
     }
-    catch (err)
-    {
+    catch (err) {
         reply.send(err);
     }
 });
 
-app.post('/signup', async (req, reply) =>
-{
+app.post('/signup', async (req, reply) => {
     const token = app.jwt.sign({ user: "userName" });
     let data = await app.jwt.verify(token);
     const user = req.user;

--- a/test.js
+++ b/test.js
@@ -59,7 +59,7 @@ test('register', function (t) {
         public: publicKey
       }
     }).ready(function (error) {
-      t.is(error, null)
+      t.is(error, undefined)
     })
   })
 
@@ -69,7 +69,7 @@ test('register', function (t) {
     fastify.register(jwt, {
       secret: Buffer.from('some secret', 'base64')
     }).ready(function (error) {
-      t.is(error, null)
+      t.is(error, undefined)
     })
   })
 
@@ -145,7 +145,7 @@ test('register', function (t) {
         audience: 'Some audience'
       }
     }).ready(function (error) {
-      t.is(error, null)
+      t.is(error, undefined)
     })
   })
 
@@ -174,7 +174,7 @@ test('register', function (t) {
           subject: 'Some subject'
         }
       }).ready(function (error) {
-        t.is(error, null)
+        t.is(error, undefined)
       })
     })
 
@@ -200,7 +200,7 @@ test('register', function (t) {
           subject: 'Some subject'
         }
       }).ready(function (error) {
-        t.is(error, null)
+        t.is(error, undefined)
       })
     })
   })


### PR DESCRIPTION
Fixes #90 Add ability to specify the token location in request headers

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
