### PR TITLE
align typings with latest fastify version

### DIFF
--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -41,13 +41,13 @@ declare module 'fastify' {
     jwt: JWT;
   }
 
-  interface FastifyReplyInterface {
+  interface FastifyReply {
     jwtSign(payload: JWTTypes.SignPayloadType, options?: jwt.SignOptions): Promise<string>;
     jwtSign(payload: JWTTypes.SignPayloadType, callback: JWTTypes.SignCallback): void;
     jwtSign(payload: JWTTypes.SignPayloadType, options: jwt.SignOptions, callback: JWTTypes.SignCallback): void;
   }
 
-  interface FastifyRequestInterface {
+  interface FastifyRequest {
     jwtVerify<Decoded extends JWTTypes.VerifyPayloadType>(options?: jwt.VerifyOptions): Promise<Decoded>;
     jwtVerify<Decoded extends JWTTypes.VerifyPayloadType>(callback: JWTTypes.VerifyCallback<Decoded>): void;
     jwtVerify<Decoded extends JWTTypes.VerifyPayloadType>(

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "steed": "^1.1.3"
   },
   "devDependencies": {
-    "fastify": "^3.0.0-rc.3",
+    "fastify": "^3.0.0-rc.4",
     "fastify-cookie": "^4.0.1",
     "standard": "^14.0.2",
     "tap": "^14.10.7",


### PR DESCRIPTION
This PR updates typings to follow the rename in the main `fastify` project.

Hopefully closes #94 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
