### PR TITLE
Add namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ fastify.register(require('fastify-jwt'), {
 
 #### namespace options
 
-You can also define a namespace to make use of multiple JWT validators on the same routes. You can comebine this with custom names for jwtVerify and JwtSign.
+You can also define a namespace to make use of multiple JWT validators on the same routes. You can combine this with custom names for `jwtVerify` and `jwtSign`.
 
 ##### Example with namespace
 

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ fastify.log.info(`Decoded JWT: ${decoded}`)
 ```
 
 ### fastify.jwt.options
-For your convenience, the `decode`, `sign`, `verify` and `messages` options you specify during `.register` are made available via `fastify.jwt.options` that will return an object  `{ decode, sign, verify, messages }` containing your options.
+For your convenience, the `decode`, `sign`, `verify`, `messages`, `namespace`, `jwtVerify` and `jwtSign` options you specify during `.register` are made available via `fastify.jwt.options` that will return an object  `{ decode, sign, verify, messages, namespace, jwtVerfiy, JwtSign }` containing your options.
 
 #### Example
 ```js
@@ -447,6 +447,23 @@ fastify.register(require('fastify-jwt'), {
   secret: 'supersecret',
   messages: myCustomMessages
 })
+```
+
+#### namespace options
+
+You can also define a namespace to make use of multiple JWT validators on the same routes. You can comebine this with custom names for jwtVerify and JwtSign.
+
+##### Example with namespace
+
+```js
+  const fastify = require('fastify')
+  
+  fastify.register(jwt, {
+    secret: 'test',
+    namespace: 'security',
+    jwtVerify: 'securityVerify',
+    jwtSign: 'securitySign'
+  })
 ```
 
 ### fastify.jwt.secret

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -27,7 +27,9 @@ export type Secret = jwt.Secret | ((request: fastify.FastifyRequest, reply: fast
 export type VerifyPayloadType = object | string
 
 export type DecodePayloadType = object | string
-
+export interface FastifyJWTNestedObject {
+  [name: string]: JWT;
+}
 export interface VerifyCallback<Decoded extends VerifyPayloadType> extends jwt.VerifyCallback {
   (err: jwt.VerifyErrors, decoded: Decoded): void
 }
@@ -75,7 +77,7 @@ export default fastifyJWT
 
 declare module 'fastify' {
   interface FastifyInstance {
-    jwt: JWT
+    jwt: JWT & FastifyJWTNestedObject;
   }
 
   interface FastifyReply {

--- a/jwt.js
+++ b/jwt.js
@@ -98,7 +98,7 @@ function fastifyJwt (fastify, options, next) {
     }
 
     if (fastify.jwt[options.namespace]) {
-      return next(new Error(`JWT namespace already used ${options.namespace}`))
+      return next(new Error(`JWT namespace already used "${options.namespace}"`))
     }
     fastify.jwt[options.namespace] = jwtConfig
   } else {

--- a/jwt.js
+++ b/jwt.js
@@ -79,8 +79,8 @@ function fastifyJwt (fastify, options, next) {
   ) {
     return next(new Error('ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret'))
   }
-
-  fastify.decorate('jwt', {
+  var namespace = options.namespace || 'jwt'
+  fastify.decorate(namespace, {
     decode: decode,
     options: {
       decode: decodeOptions,
@@ -93,9 +93,12 @@ function fastifyJwt (fastify, options, next) {
     sign: sign,
     verify: verify
   })
+
+  var jwtVerify = options.jwtVerify || 'jwtVerify'
+  var jwtSign = options.jwtSign || 'jwtSign'
   fastify.decorateRequest('user', null)
-  fastify.decorateRequest('jwtVerify', requestVerify)
-  fastify.decorateReply('jwtSign', replySign)
+  fastify.decorateRequest(jwtVerify, requestVerify)
+  fastify.decorateReply(jwtSign, replySign)
 
   next()
 

--- a/jwt.js
+++ b/jwt.js
@@ -98,7 +98,7 @@ function fastifyJwt (fastify, options, next) {
     }
 
     if (fastify.jwt[options.namespace]) {
-      throw new Error(`JWT namespace already used ${options.namespace}`)
+      return next(new Error(`JWT namespace already used ${options.namespace}`))
     }
     fastify.jwt[options.namespace] = jwtConfig
   } else {

--- a/jwt.js
+++ b/jwt.js
@@ -177,7 +177,7 @@ function fastifyJwt (fastify, options, next) {
 
     if (next === undefined) {
       return new Promise(function (resolve, reject) {
-        reply.jwtSign(payload, options, function (err, val) {
+        reply[jwtSign](payload, options, function (err, val) {
           err ? reject(err) : resolve(val)
         })
       })
@@ -211,7 +211,7 @@ function fastifyJwt (fastify, options, next) {
 
     if (next === undefined) {
       return new Promise(function (resolve, reject) {
-        request.jwtVerify(options, function (err, val) {
+        request[jwtVerify](options, function (err, val) {
           err ? reject(err) : resolve(val)
         })
       })

--- a/jwt.js
+++ b/jwt.js
@@ -105,7 +105,7 @@ function fastifyJwt (fastify, options, next) {
     fastify.decorate('jwt', jwtConfig)
   }
 
-  var jwtVerify = options.jwtVerify || 'jwtVerify'
+  const jwtVerify = options.jwtVerify || 'jwtVerify'
   var jwtSign = options.jwtSign || 'jwtSign'
   fastify.decorateRequest('user', null)
 

--- a/test.js
+++ b/test.js
@@ -2113,6 +2113,6 @@ test('Unable to add the namespace twice', function (t) {
   fastify.register(jwt, { secret: 'test', namespace: 'security', jwtVerify: 'securityVerify', jwtSign: 'securitySign' })
   fastify.register(jwt, { secret: 'hello', namespace: 'security', jwtVerify: 'secureVerify', jwtSign: 'secureSign' })
     .ready(function (err) {
-      t.is(err.message, 'JWT namespace already used security')
+      t.is(err.message, 'JWT namespace already used "security"')
     })
 })

--- a/test.js
+++ b/test.js
@@ -23,7 +23,7 @@ const privateKeyProtectedECDSA = readFileSync(`${path.join(__dirname, 'certs')}/
 const publicKeyProtectedECDSA = readFileSync(`${path.join(__dirname, 'certs')}/publicECDSA.pem`)
 
 test('register', function (t) {
-  t.plan(11)
+  t.plan(12)
 
   t.test('Expose jwt methods', function (t) {
     t.plan(7)
@@ -42,6 +42,31 @@ test('register', function (t) {
       t.ok(fastify.jwt.secret)
       t.ok(fastify.jwt.sign)
       t.ok(fastify.jwt.verify)
+    })
+
+    fastify.inject({
+      method: 'get',
+      url: '/methods'
+    })
+  })
+
+  t.test('Expose jwt methods namespaced', function (t) {
+    t.plan(7)
+
+    const fastify = Fastify()
+    fastify.register(jwt, { secret: 'test', namespace: 'security', jwtVerify: 'securityVerify', jwtSign: 'securitySign' })
+
+    fastify.get('/methods', function (request, reply) {
+      t.ok(request.securityVerify)
+      t.ok(reply.securitySign)
+    })
+
+    fastify.ready(function () {
+      t.ok(fastify.security.decode)
+      t.ok(fastify.security.options)
+      t.ok(fastify.security.secret)
+      t.ok(fastify.security.sign)
+      t.ok(fastify.security.verify)
     })
 
     fastify.inject({

--- a/test.js
+++ b/test.js
@@ -62,11 +62,11 @@ test('register', function (t) {
     })
 
     fastify.ready(function () {
-      t.ok(fastify.security.decode)
-      t.ok(fastify.security.options)
-      t.ok(fastify.security.secret)
-      t.ok(fastify.security.sign)
-      t.ok(fastify.security.verify)
+      t.ok(fastify.jwt.security.decode)
+      t.ok(fastify.jwt.security.options)
+      t.ok(fastify.jwt.security.secret)
+      t.ok(fastify.jwt.security.sign)
+      t.ok(fastify.jwt.security.verify)
     })
 
     fastify.inject({


### PR DESCRIPTION
I've added the ability to customize the jwt property that is placed on the fastify instance and allowed to customize function names on reply and request.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
