### PR TITLE
📝Fix TS snippet in the docs by adding the module keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ Define custom Payload Type
 > [typescript declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)
 
 ```ts
-declare "fastify-jwt" {
+declare module "fastify-jwt" {
   interface FastifyJWT {
     payload: { name: string }
   }


### PR DESCRIPTION
Add the `module` keyword to the declaration merging snippet in the TS section in the README file