### PR TITLE
feat: support promise/async secret function

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,23 @@ const fastify = require('fastify')()
 const jwt = require('fastify-jwt')
 // secret as a string
 fastify.register(jwt, { secret: 'supersecret' })
-// secret as a function
+// secret as a function with callback
 fastify.register(jwt, {
   secret: function (request, token, callback) {
     // do something
     callback(null, 'supersecret')
+  }
+})
+// secret as a function returning a promise
+fastify.register(jwt, {
+  secret: function (request, token) {
+    return Promise.resolve('supersecret')
+  }
+})
+// secret as an async function
+fastify.register(jwt, {
+  secret: async function (request, token) {
+    return 'supersecret'
   }
 })
 // secret as an object of RSA keys (without passphrase)

--- a/README.md
+++ b/README.md
@@ -570,10 +570,9 @@ const getJwks = buildGetJwks()
 
 fastify.register(fjwt, {
   decode: { complete: true },
-  secret: (request, token, callback) => {
+  secret: (request, token) => {
     const { header: { kid, alg }, payload: { iss } } = token
-    getJwks.getPublicKey({ kid, domain: iss, alg })
-      .then(publicKey => callback(null, publicKey), callback)
+    return getJwks.getPublicKey({ kid, domain: iss, alg })
   }
 })
 

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -37,7 +37,11 @@ export type UserType = FastifyJWT extends { user: infer T }
   ? T
   : SignPayloadType
 
-export type Secret = jwt.Secret | ((request: fastify.FastifyRequest, reply: fastify.FastifyReply, cb: (e: Error | null, secret: string | undefined) => void) => void)
+export type TokenOrHeader = jwt.JwtHeader | { header: jwt.JwtHeader; payload: any }
+
+export type Secret = jwt.Secret 
+| ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader, cb: (e: Error | null, secret: string | undefined) => void) => void)
+| ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader) => Promise<string>)
 
 export type VerifyPayloadType = object | string
 

--- a/jwt.js
+++ b/jwt.js
@@ -51,8 +51,12 @@ function fastifyJwt (fastify, options, next) {
 
   let secretCallbackSign = secretOrPrivateKey
   let secretCallbackVerify = secretOrPublicKey
-  if (typeof secretCallbackSign !== 'function') { secretCallbackSign = wrapStaticSecretInCallback(secretCallbackSign) }
-  if (typeof secretCallbackVerify !== 'function') { secretCallbackVerify = wrapStaticSecretInCallback(secretCallbackVerify) }
+  if (typeof secretCallbackSign !== 'function') {
+    secretCallbackSign = wrapStaticSecretInCallback(secretCallbackSign)
+  }
+  if (typeof secretCallbackVerify !== 'function') {
+    secretCallbackVerify = wrapStaticSecretInCallback(secretCallbackVerify)
+  }
 
   const cookie = options.cookie
   const formatUser = options.formatUser
@@ -175,7 +179,11 @@ function fastifyJwt (fastify, options, next) {
 
     steed.waterfall([
       function getSecret (callback) {
-        secretCallbackSign(reply.request, payload, callback)
+        const signResult = secretCallbackSign(reply.request, payload, callback)
+
+        if (signResult && typeof signResult.then === 'function') {
+          signResult.then(result => callback(null, result), callback)
+        }
       },
       function sign (secretOrPrivateKey, callback) {
         jwt.sign(payload, secretOrPrivateKey, options, callback)
@@ -240,7 +248,11 @@ function fastifyJwt (fastify, options, next) {
 
     steed.waterfall([
       function getSecret (callback) {
-        secretCallbackVerify(request, decodedToken, callback)
+        const verifyResult = secretCallbackVerify(request, decodedToken, callback)
+
+        if (verifyResult && typeof verifyResult.then === 'function') {
+          verifyResult.then(result => callback(null, result), callback)
+        }
       },
       function verify (secretOrPublicKey, callback) {
         jwt.verify(token, secretOrPublicKey, options, (err, result) => {

--- a/jwt.test-d.ts
+++ b/jwt.test-d.ts
@@ -4,23 +4,27 @@ import { expectAssignable } from 'tsd'
 
 const app = fastify();
 
+const secretOptions = {
+  secret: 'supersecret',
+  publicPrivateKey: {
+    public: 'publicKey',
+    private: 'privateKey'
+  },
+  secretFnCallback: (_req, _token, cb) => { cb(null, 'supersecret') },
+  secretFnPromise: (_req, _token) => Promise.resolve('supersecret'),
+  secretFnAsync: async (_req, _token) => 'supersecret',
+  publicPrivateKeyFn: {
+    public: (_req, _rep, cb) => { cb(null, 'publicKey') },
+    private: 'privateKey'
+  },
+  publicPrivateKeyFn2: {
+    public: 'publicKey',
+    private: (_req, _rep, cb) => { cb(null, 'privateKey') },
+  }
+}
+
 const jwtOptions: FastifyJWTOptions = {
-  secret: {
-    secret: 'supersecret',
-    publicPrivateKey: {
-      public: 'publicKey',
-      private: 'privateKey'
-    },
-    secretFn: (_req, _rep, cb) => { cb(null, 'supersecret') },
-    publicPrivateKeyFn: {
-      public: (_req, _rep, cb) => { cb(null, 'publicKey') },
-      private: 'privateKey'
-    },
-    publicPrivateKeyFn2: {
-      public: 'publicKey',
-      private: (_req, _rep, cb) => { cb(null, 'privateKey') },
-    }
-  }[process.env.secretOption!],
+  secret: 'supersecret',
   sign: {
     expiresIn: '1h'
   },
@@ -53,6 +57,10 @@ const jwtOptions: FastifyJWTOptions = {
 }
 
 app.register(fastifyJwt, jwtOptions);
+
+Object.values(secretOptions).forEach((value) => {
+  app.register(fastifyJwt, {...jwtOptions, secret: value });
+})
 
 app.register(fastifyJwt, {...jwtOptions, trusted: () => Promise.resolve(false || '' || Buffer.from('foo')) })
 


### PR DESCRIPTION
Support `secret` option as a function returning a promise or an async function.

Note that the typescript types are quite off already and they're not testing much as far as the secret function is concerned. I'm not using typescript so I have not fixed them, but for example the parameters provided to the pre-existing `secret` provided as a function are already wrong, i.e. the second argument is not the Reply but rather the decoded token. **I did not fix this**.

Supersedes https://github.com/fastify/fastify-jwt/pull/140 and closes https://github.com/fastify/fastify-jwt/issues/139

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
