### PR TITLE
feat: Verify JWT from a signed cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ In some situations you may want to store a token in a cookie. This allows you to
 - The request has both the authorization and cookie header
 - Cookie is empty, authorization header is present
 
+If you are signing your cookie, you can set the `signed` boolean to `true` which will make sure the JWT is verified using the unsigned value.
+
 ```js
 const fastify = require('fastify')()
 const jwt = require('fastify-jwt')
@@ -253,7 +255,8 @@ const jwt = require('fastify-jwt')
 fastify.register(jwt, {
   secret: 'foobar'
   cookie: {
-    cookieName: 'token'
+    cookieName: 'token',
+    signed: false
   }
 })
 

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -39,7 +39,7 @@ export type UserType = FastifyJWT extends { user: infer T }
 
 export type TokenOrHeader = jwt.JwtHeader | { header: jwt.JwtHeader; payload: any }
 
-export type Secret = jwt.Secret 
+export type Secret = jwt.Secret
 | ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader, cb: (e: Error | null, secret: string | undefined) => void) => void)
 | ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader) => Promise<string>)
 
@@ -57,7 +57,8 @@ export interface FastifyJWTOptions {
   sign?: jwt.SignOptions
   verify?: jwt.VerifyOptions & { extractToken?: (request: fastify.FastifyRequest) => string | void }
   cookie?: {
-    cookieName: string
+    cookieName: string,
+    signed: boolean
   }
   messages?: {
     badRequestErrorMessage?: string

--- a/jwt.js
+++ b/jwt.js
@@ -233,7 +233,9 @@ function fastifyJwt (fastify, options, next) {
     } else if (cookie) {
       if (request.cookies) {
         if (request.cookies[cookie.cookieName]) {
-          token = request.cookies[cookie.cookieName]
+          const tokenValue = request.cookies[cookie.cookieName]
+
+          token = cookie.signed ? request.unsignCookie(tokenValue).value : tokenValue
         } else {
           return next(new Unauthorized(messagesOptions.noAuthorizationInCookieMessage))
         }

--- a/jwt.test-d.ts
+++ b/jwt.test-d.ts
@@ -29,7 +29,8 @@ const jwtOptions: FastifyJWTOptions = {
     expiresIn: '1h'
   },
   cookie: {
-    cookieName: 'jwt'
+    cookieName: 'jwt',
+    signed: false
   },
   verify: {
     maxAge: '1h',


### PR DESCRIPTION
Closes #151 

This PR adds the ability to verify a JWT from `fastify-cookie` when the cookie is signed with a secret. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
