### PR TITLE
Misleading documentation ref. jsonwebtoken doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ npm i fastify-jwt --save
 ```
 
 ## Usage
-Register as a plugin. This will decorate your `fastify` instance with the standard [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken) methods `decode`, `sign`, and `verify`; refer to their documentation to find how to use the utilities. It will also register `request.jwtVerify` and `reply.jwtSign`. You must pass a `secret` when registering the plugin.
+Register as a plugin. This will decorate your `fastify` instance with the standard [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken) methods `decode`, `sign`, and `verify`; refer to their documentation to find how to use the utilities. It will also register `request.jwtVerify` and `reply.jwtSign`. You must pass a `secret` when registering the plugin.  
+```
+Passing a Secret Key in any function will result with an error, it's being inserted automatically.
+```
 
 ```js
 const fastify = require('fastify')()


### PR DESCRIPTION
This caused me 2h of trouble because the documentation saying "refer to jsonwebtoken documentation".

The fastify-jwt and jsonwebtoken methods aren't 100% equal, therefore misleading.

https://github.com/fastify/help/issues/506

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
