### PR TITLE
fix: ECDSA key pair generation and related documentation

### DIFF
--- a/example/UsingCertificates.md
+++ b/example/UsingCertificates.md
@@ -63,7 +63,7 @@ Certificates `privateECDSA.key` and `publicECDSA.key` are generated with the fol
 
 ```sh
 # generate a P-256 curve ECDSA key pair
-openssl ecparam -genkey -name secp256k1 -out privateECDSA.key
+openssl ecparam -genkey -name prime256v1 -out privateECDSA.key
 
 # export the ECDSA public key to a file
 openssl ec -in privateECDSA.key -pubout -out publicECDSA.key
@@ -81,7 +81,7 @@ fastify.register(jwt, {
     private: readFileSync('path/to/privateECDSA.key', 'utf8'),
     public: readFileSync('path/to/publicECDSA.key', 'utf8')
   },
-  sign: { algorithm: 'RS256' }
+  sign: { algorithm: 'ES256' }
 })
 ```
 
@@ -92,7 +92,7 @@ Certificates `privateECDSA.pem` and `publicECDSA.pem` are generated with the fol
 ```sh
 # generate a P-256 curve ECDSA key pair, and encrypts them with a passphrase
 # the passphrase I choose for the demo files is: super secret passphrase
-openssl ecparam -genkey -name secp256k1 | openssl ec -aes256 -out privateECDSA.pem
+openssl ecparam -genkey -name prime256v1 | openssl ec -aes256 -out privateECDSA.pem
 
 # export the ECDSA public key to a file
 openssl ec -in privateECDSA.pem -pubout -out publicECDSA.pem
@@ -113,6 +113,6 @@ fastify.register(jwt, {
     },
     public: readFileSync('path/to/publicECDSA.pem', 'utf8')
   },
-  sign: { algorithm: 'RS256' }
+  sign: { algorithm: 'ES256' }
 })
 ```

--- a/example/UsingCertificates.md
+++ b/example/UsingCertificates.md
@@ -5,7 +5,7 @@
 Certificates `private.key` and `public.key` are generated with http://travistidwell.com/jsencrypt/demo/ or with the following command
 
 ```sh
-openssl genrsa -out private.key 1024
+openssl genrsa -out private.key 2048
 openssl rsa -in private.key -out public.key -outform PEM -pubout
 ```
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -39,7 +39,7 @@ function generateKeyPairProtected (passphrase) {
 function generateKeyPairECDSA () {
   const options = {
     modulusLength: 2048,
-    namedCurve: 'secp256k1',
+    namedCurve: 'prime256v1',
     publicKeyEncoding: {
       type: 'spki',
       format: 'pem'
@@ -55,7 +55,7 @@ function generateKeyPairECDSA () {
 function generateKeyPairECDSAProtected (passphrase) {
   const options = {
     modulusLength: 2048,
-    namedCurve: 'secp256k1',
+    namedCurve: 'prime256v1',
     publicKeyEncoding: {
       type: 'spki',
       format: 'pem'


### PR DESCRIPTION
Hello.
* Fixes tests by generating an `ES256` (used curve: `prime256v1`) key pair, using a `secp256k1` curve generates an `ES256K` key pair (currently not supported by `jsonwebtoken` or `fast-jwt` in the upcoming release).
* Updates the related documentation.

For reference: [rfc8812 - section 3.2](https://datatracker.ietf.org/doc/html/rfc8812#section-3.2).

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
