### PR TITLE
chore: Remove JwtHeader type definition

### DIFF
--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -1,4 +1,4 @@
-import { DecoderOptions, KeyFetcher, SignerCallback, SignerOptions, VerifierCallback, VerifierOptions } from 'fast-jwt'
+import { DecoderOptions, KeyFetcher, SignerCallback, SignerOptions, VerifierCallback, VerifierOptions, JwtHeader } from 'fast-jwt'
 import * as fastify from 'fastify'
 
 /**
@@ -36,21 +36,6 @@ export type SignPayloadType = FastifyJWT extends { payload: infer T }
 export type UserType = FastifyJWT extends { user: infer T }
   ? T
   : SignPayloadType
-
-// standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
-// same interface as in jsonwebtoken lib - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jsonwebtoken/index.d.ts
-export interface JwtHeader {
-    alg: string | Algorithm;
-    typ?: string | undefined;
-    cty?: string | undefined;
-    crit?: Array<string | Exclude<keyof JwtHeader, 'crit'>> | undefined;
-    kid?: string | undefined;
-    jku?: string | undefined;
-    x5u?: string | string[] | undefined;
-    'x5t#S256'?: string | undefined;
-    x5t?: string | undefined;
-    x5c?: string | string[] | undefined;
-}
 
 export type TokenOrHeader = JwtHeader | { header: JwtHeader; payload: any }
 

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -115,6 +115,8 @@ export interface JWT {
   decode<Decoded extends DecodePayloadType>(token: string, options?: Partial<DecoderOptions>): null | Decoded
 }
 
+export type { JwtHeader } from 'fast-jwt'
+
 export const fastifyJWT: fastify.FastifyPluginCallback<FastifyJWTOptions>
 
 export default fastifyJWT

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -1,4 +1,12 @@
-import { DecoderOptions, KeyFetcher, SignerCallback, SignerOptions, VerifierCallback, VerifierOptions, JwtHeader } from 'fast-jwt'
+import {
+  DecoderOptions,
+  JwtHeader,
+  KeyFetcher,
+  SignerCallback,
+  SignerOptions,
+  VerifierCallback,
+  VerifierOptions
+} from 'fast-jwt'
 import * as fastify from 'fastify'
 
 /**

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/fastify/fastify-jwt#readme",
   "dependencies": {
     "@lukeed/ms": "^2.0.0",
-    "fast-jwt": "https://github.com/nearform/fast-jwt#master",
+    "fast-jwt": "^1.4.0",
     "fastify-plugin": "^3.0.0",
     "http-errors": "^1.8.1",
     "steed": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/fastify/fastify-jwt#readme",
   "dependencies": {
     "@lukeed/ms": "^2.0.0",
-    "fast-jwt": "^1.3.2",
+    "fast-jwt": "https://github.com/nearform/fast-jwt#master",
     "fastify-plugin": "^3.0.0",
     "http-errors": "^1.8.1",
     "steed": "^1.1.3"

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1424,7 +1424,7 @@ test('decode', function (t) {
 })
 
 test('errors', function (t) {
-  t.plan(11)
+  t.plan(12)
 
   const fastify = Fastify()
   fastify.register(jwt, { secret: 'test', trusted: (request, { jti }) => jti !== 'untrusted' })


### PR DESCRIPTION
As mentioned in #188, this PR removes the JwtHeader type definition from this repository and uses the one from [fast-jwt](https://github.com/nearform/fast-jwt/blob/eff9cfeb0d7e2b24d04c1b37f7870447f4881eb1/src/index.d.ts#L56).

The PR needs to be updated once https://github.com/nearform/fast-jwt/issues/155 is released as it is currently pointing to the master branch.

Closes #188 
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

