### PR TITLE
secret function can also return a Buffer as type

### DIFF
--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -48,8 +48,8 @@ export type UserType = FastifyJWT extends { user: infer T }
 export type TokenOrHeader = JwtHeader | { header: JwtHeader; payload: any }
 
 export type Secret = string | Buffer | KeyFetcher
-| ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader, cb: (e: Error | null, secret: string | undefined) => void) => void)
-| ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader) => Promise<string>)
+| ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader, cb: (e: Error | null, secret: string | Buffer | undefined) => void) => void)
+| ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader) => Promise<string | Buffer>)
 
 export type VerifyPayloadType = object | string
 export type DecodePayloadType = object | string

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -14,7 +14,7 @@ const { privateKey, publicKey } = helper.generateKeyPair()
 const { privateKey: privateKeyECDSA, publicKey: publicKeyECDSA } = helper.generateKeyPairECDSA()
 
 test('register', function (t) {
-  t.plan(14)
+  t.plan(20)
 
   t.test('Expose jwt methods', function (t) {
     t.plan(8)
@@ -99,6 +99,36 @@ test('register', function (t) {
     const fastify = Fastify()
     fastify.register(jwt, {
       secret: Buffer.from('some secret', 'base64')
+    }).ready(function (error) {
+      t.equal(error, undefined)
+    })
+  })
+
+  t.test('secret as a function with a callback returning a Buffer', function (t) {
+    t.plan(1)
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: (request, token, callback) => { callback(null, Buffer.from('some secret', 'base64')) }
+    }).ready(function (error) {
+      t.equal(error, undefined)
+    })
+  })
+
+  t.test('secret as a function returning a promise with Buffer', function (t) {
+    t.plan(1)
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: (request, token) => Promise.resolve(Buffer.from('some secret', 'base64'))
+    }).ready(function (error) {
+      t.equal(error, undefined)
+    })
+  })
+
+  t.test('secret as an async function returning a Buffer', function (t) {
+    t.plan(1)
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async (request, token) => Buffer.from('some secret', 'base64')
     }).ready(function (error) {
       t.equal(error, undefined)
     })
@@ -360,6 +390,24 @@ test('register', function (t) {
   t.test('secret as an async function', t => {
     return runWithSecret(t, async function (request, token) {
       return 'some-secret'
+    })
+  })
+
+  t.test('secret as a function with callback returning a Buffer', t => {
+    return runWithSecret(t, function (request, token, callback) {
+      callback(null, Buffer.from('some-secret', 'base64'))
+    })
+  })
+
+  t.test('secret as a function returning a promise with a Buffer', t => {
+    return runWithSecret(t, function (request, token) {
+      return Promise.resolve(Buffer.from('some secret', 'base64'))
+    })
+  })
+
+  t.test('secret as an async function returning a Buffer', t => {
+    return runWithSecret(t, async function (request, token) {
+      return Buffer.from('some secret', 'base64')
     })
   })
 

--- a/test/types/jwt.test-d.ts
+++ b/test/types/jwt.test-d.ts
@@ -13,6 +13,9 @@ const secretOptions = {
   secretFnCallback: (_req, _token, cb) => { cb(null, 'supersecret') },
   secretFnPromise: (_req, _token) => Promise.resolve('supersecret'),
   secretFnAsync: async (_req, _token) => 'supersecret',
+  secretFnBufferCallback: (_req, _token, cb) => { cb(null, Buffer.from('some secret', 'base64')) },
+  secretFnBufferPromise: (_req, _token) => Promise.resolve(Buffer.from('some secret', 'base64')),
+  secretFnBufferAsync: async (_req, _token) => Buffer.from('some secret', 'base64'),
   publicPrivateKeyFn: {
     public: (_req, _rep, cb) => { cb(null, 'publicKey') },
     private: 'privateKey'


### PR DESCRIPTION
Instead of just a string, the secret returned from the callback/promise can also be a Buffer

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
