### PR TITLE
chore: remove named export of fastifyJwt

### DIFF
--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -117,7 +117,7 @@ export interface JWT {
 
 export type { JwtHeader } from 'fast-jwt'
 
-export const fastifyJWT: fastify.FastifyPluginCallback<FastifyJWTOptions>
+declare const fastifyJWT: fastify.FastifyPluginCallback<FastifyJWTOptions>
 
 export default fastifyJWT
 

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -117,9 +117,9 @@ export interface JWT {
 
 export type { JwtHeader } from 'fast-jwt'
 
-declare const fastifyJWT: fastify.FastifyPluginCallback<FastifyJWTOptions>
+export const fastifyJwt: fastify.FastifyPluginCallback<FastifyJWTOptions>
 
-export default fastifyJWT
+export default fastifyJwt
 
 export interface FastifyJwtSignOptions {
   sign?: Partial<SignOptions>

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -4,6 +4,8 @@ const test = require('tap').test
 const Fastify = require('fastify')
 const { createSigner } = require('fast-jwt')
 const jwt = require('../jwt')
+const defaultExport = require('../jwt').default
+const { fastifyJwt: namedExport } = require('../jwt')
 
 const helper = require('./helper')
 
@@ -12,6 +14,25 @@ const { privateKey: privateKeyProtected, publicKey: publicKeyProtected } = helpe
 const { privateKey: privateKeyProtectedECDSA, publicKey: publicKeyProtectedECDSA } = helper.generateKeyPairECDSAProtected(passphrase)
 const { privateKey, publicKey } = helper.generateKeyPair()
 const { privateKey: privateKeyECDSA, publicKey: publicKeyECDSA } = helper.generateKeyPairECDSA()
+
+test('export', function (t) {
+  t.plan(3)
+
+  t.test('module export', function (t) {
+    t.plan(1)
+    t.equal(typeof jwt, 'function')
+  })
+
+  t.test('default export', function (t) {
+    t.plan(1)
+    t.equal(typeof defaultExport, 'function')
+  })
+
+  t.test('named export', function (t) {
+    t.plan(1)
+    t.equal(typeof namedExport, 'function')
+  })
+})
 
 test('register', function (t) {
   t.plan(20)


### PR DESCRIPTION
Implementation of this plugin doesn't support named imports. That is why `jwt.d.ts` has been actualized. 
Closes #150 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
