### PR TITLE
fix: reply.jwtSign sets wrong exp

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -308,6 +308,16 @@ function fastifyJwt (fastify, options, next) {
       useLocalSigner = false
     }
 
+    const reply = this
+
+    if (next === undefined) {
+      return new Promise(function (resolve, reject) {
+        reply[jwtSignName](payload, options, function (err, val) {
+          err ? reject(err) : resolve(val)
+        })
+      })
+    }
+
     if (options.sign) {
       convertTemporalProps(options.sign)
       // New supported contract, options supports sign and can expand
@@ -318,16 +328,6 @@ function fastifyJwt (fastify, options, next) {
       convertTemporalProps(options)
       // Original contract, options supports only sign
       options = mergeOptionsWithKey({ ...signOptions, ...options }, true)
-    }
-
-    const reply = this
-
-    if (next === undefined) {
-      return new Promise(function (resolve, reject) {
-        reply[jwtSignName](payload, options, function (err, val) {
-          err ? reject(err) : resolve(val)
-        })
-      })
     }
 
     if (!payload) {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -2593,6 +2593,8 @@ test('supporting time definitions for "maxAge", "expiresIn" and "notBefore"', as
     jwtDecode: true
   }
 
+  const oneDayInSeconds = 24 * 60 * 60
+
   const fastify = Fastify()
   fastify.register(jwt, { secret: 'test', ...options })
 
@@ -2614,7 +2616,7 @@ test('supporting time definitions for "maxAge", "expiresIn" and "notBefore"', as
   await fastify.ready()
 
   t.test('options are functions', function (t) {
-    t.plan(6)
+    t.plan(7)
     fastify.jwt.sign({ foo: 'bar' }, (err, token) => {
       t.error(err)
       t.ok(token)
@@ -2624,6 +2626,7 @@ test('supporting time definitions for "maxAge", "expiresIn" and "notBefore"', as
         t.ok(result)
         t.ok(result.exp)
         t.equal(typeof result.exp, 'number')
+        t.equal(result.exp - result.iat, oneDayInSeconds)
       })
     })
   })
@@ -2637,6 +2640,14 @@ test('supporting time definitions for "maxAge", "expiresIn" and "notBefore"', as
 
     const token = JSON.parse(signResponse.payload).token
     t.ok(token)
+    fastify.jwt.verify(token, { secret: 'test' }, (err, result) => {
+      t.error(err)
+      t.ok(result)
+      t.ok(result.exp)
+      t.equal(typeof result.exp, 'number')
+      t.equal(result.iss, 'foo')
+      t.equal(result.exp - result.iat, oneDayInSeconds)
+    })
   })
 
   t.test('general options defined and merged with signOptions', async function (t) {
@@ -2661,6 +2672,7 @@ test('supporting time definitions for "maxAge", "expiresIn" and "notBefore"', as
     t.ok(decodedToken)
     t.ok(decodedToken.payload.exp)
     t.equal(typeof decodedToken.payload.exp, 'number')
+    t.equal(decodedToken.payload.exp - decodedToken.payload.iat, oneDayInSeconds)
     t.ok(decodedToken.payload.nbf)
     t.equal(typeof decodedToken.payload.nbf, 'number')
   })


### PR DESCRIPTION
When using reply.jwtSign without a callback convertTemporealProps gets called two times multiplying time props twice incorrectly.

- move the check for the callback before the call to convertTemporalProps, so they are not called twice
- add assertions checking token exp prop to existing time definitions tests

Closes #207
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
