### PR TITLE
Change decorator name

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,19 @@ fastify.register(require('@fastify/jwt'), {
 })
 ```
 
+### `decoratorName`
+If this plugin is used together with fastify/passport, we might get an error as both plugins use the same name for a decorator. We can change the name of the decorator, or `user` will default
+
+#### Example
+
+```js
+const fastify = require('fastify')
+fastify.register(require('@fastify/jwt'), {
+  secret: 'supersecret',
+  decoratorName: 'customName'
+})
+```
+
 ### `decode`
 
 * `complete`: Return an object with the decoded header, payload, signature and input (the token part before the signature), instead of just the content of the payload. Default is `false`.

--- a/jwt.js
+++ b/jwt.js
@@ -144,7 +144,7 @@ function fastifyJwt (fastify, options, next) {
   let jwtSignName = 'jwtSign'
   if (namespace) {
     if (!fastify.jwt) {
-      fastify.decorateRequest('user', null)
+      fastify.decorateRequest('jwtUser', null)
       fastify.decorate('jwt', Object.create(null))
     }
 
@@ -157,7 +157,7 @@ function fastifyJwt (fastify, options, next) {
     jwtVerifyName = jwtVerify || `${namespace}JwtVerify`
     jwtSignName = jwtSign || `${namespace}JwtSign`
   } else {
-    fastify.decorateRequest('user', null)
+    fastify.decorateRequest('jwtUser', null)
     fastify.decorate('jwt', jwtDecorator)
   }
 

--- a/jwt.js
+++ b/jwt.js
@@ -142,9 +142,10 @@ function fastifyJwt (fastify, options, next) {
   let jwtDecodeName = 'jwtDecode'
   let jwtVerifyName = 'jwtVerify'
   let jwtSignName = 'jwtSign'
+  const jwtDecoratorName = process.env.JWT_DECORATOR_NAME || 'user'
   if (namespace) {
     if (!fastify.jwt) {
-      fastify.decorateRequest('jwtUser', null)
+      fastify.decorateRequest(jwtDecoratorName, null)
       fastify.decorate('jwt', Object.create(null))
     }
 
@@ -157,7 +158,7 @@ function fastifyJwt (fastify, options, next) {
     jwtVerifyName = jwtVerify || `${namespace}JwtVerify`
     jwtSignName = jwtSign || `${namespace}JwtSign`
   } else {
-    fastify.decorateRequest('jwtUser', null)
+    fastify.decorateRequest(jwtDecoratorName, null)
     fastify.decorate('jwt', jwtDecorator)
   }
 

--- a/jwt.js
+++ b/jwt.js
@@ -75,6 +75,7 @@ function fastifyJwt (fastify, options, next) {
     secret,
     sign: initialSignOptions = {},
     trusted,
+    decoratorName = 'user',
     verify: initialVerifyOptions = {},
     ...pluginOptions
   } = options
@@ -142,10 +143,9 @@ function fastifyJwt (fastify, options, next) {
   let jwtDecodeName = 'jwtDecode'
   let jwtVerifyName = 'jwtVerify'
   let jwtSignName = 'jwtSign'
-  const jwtDecoratorName = process.env.JWT_DECORATOR_NAME || 'user'
   if (namespace) {
     if (!fastify.jwt) {
-      fastify.decorateRequest(jwtDecoratorName, null)
+      fastify.decorateRequest(decoratorName, null)
       fastify.decorate('jwt', Object.create(null))
     }
 
@@ -158,7 +158,7 @@ function fastifyJwt (fastify, options, next) {
     jwtVerifyName = jwtVerify || `${namespace}JwtVerify`
     jwtSignName = jwtSign || `${namespace}JwtSign`
   } else {
-    fastify.decorateRequest(jwtDecoratorName, null)
+    fastify.decorateRequest(decoratorName, null)
     fastify.decorate('jwt', jwtDecorator)
   }
 

--- a/jwt.js
+++ b/jwt.js
@@ -132,7 +132,8 @@ function fastifyJwt (fastify, options, next) {
       decode: decodeOptions,
       sign: initialSignOptions,
       verify: initialVerifyOptions,
-      messages: messagesOptions
+      messages: messagesOptions,
+      decoratorName
     },
     cookie,
     sign,

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -2714,3 +2714,25 @@ test('global user options should not be modified', async function (t) {
   t.equal(fastify.jwt.options.sign.notBefore, '4 hours')
   t.equal(fastify.jwt.options.verify.maxAge, 2000)
 })
+
+test('decorator name should work after being changed in the env', async function (t) {
+  t.plan(1)
+
+  process.env.JWT_DECORATOR_NAME = 'jwtUser'
+
+  const fastify = Fastify()
+  fastify.register(jwt, { secret: 'test' })
+
+  fastify.post('/sign', async function (request, reply) {
+    const token = await reply.jwtSign(request.body)
+    return { token }
+  })
+
+  const signResponse = await fastify.inject({
+    method: 'post',
+    url: '/sign',
+    payload: { foo: 'bar' }
+  })
+  const token = JSON.parse(signResponse.payload).token
+  t.ok(token)
+})

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -2718,10 +2718,8 @@ test('global user options should not be modified', async function (t) {
 test('decorator name should work after being changed in the env', async function (t) {
   t.plan(1)
 
-  process.env.JWT_DECORATOR_NAME = 'jwtUser'
-
   const fastify = Fastify()
-  fastify.register(jwt, { secret: 'test' })
+  fastify.register(jwt, { secret: 'test', decoratorName: 'customName' })
 
   fastify.post('/sign', async function (request, reply) {
     const token = await reply.jwtSign(request.body)

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -2715,7 +2715,7 @@ test('global user options should not be modified', async function (t) {
   t.equal(fastify.jwt.options.verify.maxAge, 2000)
 })
 
-test('decorator name should work after being changed in the env', async function (t) {
+test('decorator name should work after being changed in the options', async function (t) {
   t.plan(1)
 
   const fastify = Fastify()

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -2716,10 +2716,11 @@ test('global user options should not be modified', async function (t) {
 })
 
 test('decorator name should work after being changed in the options', async function (t) {
-  t.plan(1)
+  t.plan(3)
 
   const fastify = Fastify()
-  fastify.register(jwt, { secret: 'test', decoratorName: 'customName' })
+  const decoratorName = 'customName'
+  fastify.register(jwt, { secret: 'test', decoratorName: decoratorName })
 
   fastify.post('/sign', async function (request, reply) {
     const token = await reply.jwtSign(request.body)
@@ -2733,4 +2734,6 @@ test('decorator name should work after being changed in the options', async func
   })
   const token = JSON.parse(signResponse.payload).token
   t.ok(token)
+  t.ok(fastify.jwt.options.decoratorName)
+  t.equal(fastify.jwt.options.decoratorName, decoratorName)
 })


### PR DESCRIPTION
Changed decorator name to avoid conflict with @fastify/passport plugin using the same decorator

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
