### PR TITLE
onlyCookie option for jwtVerify

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ fastify.listen(3000, err => {
 
 ### `onlyCookie`
 
-Setting this options to `true` will decode only yhe cookie jwt stored in the request. This is useful for refreshToken implementations where the user is set two tokens. One for the main authentication which has a shorter timeout and refresh token normally stored in the cookie which has a longer timeout. This allows you to check to make sure that the cookie token is still valid if it has a different expiring time than the main token.
+Setting this options to `true` will decode only the cookie in the request. This is useful for refreshToken implementations where the request typically has two tokens: token and refreshToken. The main authentication token usually has a shorter timeout and the refresh token normally stored in the cookie has a longer timeout. This allows you to check to make sure that the cookie token is still valid, as it could have a different expiring time than the main token. The payloads of the two different tokens could also be different.
 
 ```js
 const fastify = require('fastify')()

--- a/jwt.js
+++ b/jwt.js
@@ -199,12 +199,13 @@ function fastifyJwt (fastify, options, next) {
 
     let token
     const extractToken = options.extractToken
+    const onlyCookie = options.onlyCookie
     if (extractToken) {
       token = extractToken(request)
       if (!token) {
         throw new BadRequest(messagesOptions.badRequestErrorMessage)
       }
-    } else if (request.headers && request.headers.authorization) {
+    } else if ((request.headers && request.headers.authorization) && (!onlyCookie)) {
       const parts = request.headers.authorization.split(' ')
       if (parts.length === 2) {
         const scheme = parts[0]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
