### PR TITLE
Add decoratorName in the request object instead of default user

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -496,7 +496,7 @@ function fastifyJwt (fastify, options, next) {
         next(err)
       } else {
         const user = formatUser ? formatUser(result) : result
-        request.user = user
+        request[decoratorName] = user
         next(null, user)
       }
     })


### PR DESCRIPTION

Replaced a line missed in pull https://github.com/fastify/fastify-jwt/pull/229 , where the old `request.user` was still used, with the new decoratorName variable 


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
