### PR TITLE
fix: add type to support ES256 with passphrase in TypeScript

### DIFF
--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -47,7 +47,7 @@ export type UserType = FastifyJWT extends { user: infer T }
 
 export type TokenOrHeader = JwtHeader | { header: JwtHeader; payload: any }
 
-export type Secret = string | Buffer | KeyFetcher
+export type Secret = string | Buffer | KeyFetcher | { key: Secret; passphrase: string }
 | ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader, cb: (e: Error | null, secret: string | Buffer | undefined) => void) => void)
 | ((request: fastify.FastifyRequest, tokenOrHeader: TokenOrHeader) => Promise<string | Buffer>)
 

--- a/test/types/jwt.test-d.ts
+++ b/test/types/jwt.test-d.ts
@@ -74,6 +74,17 @@ Object.values(secretOptions).forEach((value) => {
 
 app.register(fastifyJwt, {...jwtOptions, trusted: () => Promise.resolve(false || '' || Buffer.from('foo')) })
 
+app.register(fastifyJwt, {
+  secret: {
+    private: {
+      key: 'privateKey',
+      passphrase: 'super secret passphrase',
+    },
+    public: 'publicKey',
+  },
+  sign: { algorithm: 'ES256' },
+})
+
 // expect jwt and its subsequent methods have merged with the fastify instance
 expectAssignable<object>(app.jwt)
 expectAssignable<Function>(app.jwt.sign)


### PR DESCRIPTION
Add new type definition to support ES256 with passphrase in TypeScript.

Closes #246 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
