### PR TITLE
Add `onlyCookie` verify option tests and types

### DIFF
--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -65,6 +65,7 @@ export interface SignOptions extends Omit<SignerOptions, "expiresIn" | "notBefor
 
 export interface VerifyOptions extends Omit<VerifierOptions, "maxAge"> {
   maxAge: number | string;
+  onlyCookie: boolean;
 }
 
 export interface FastifyJWTOptions {
@@ -140,7 +141,7 @@ export interface FastifyJwtDecodeOptions {
 
 declare module 'fastify' {
   interface FastifyInstance {
-    jwt: JWT
+    jwt: JWT & { [namespace: string]: JWT }
   }
 
   interface FastifyReply {

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -141,7 +141,7 @@ export interface FastifyJwtDecodeOptions {
 
 declare module 'fastify' {
   interface FastifyInstance {
-    jwt: JWT & { [namespace: string]: JWT }
+    jwt: JWT
   }
 
   interface FastifyReply {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1897,7 +1897,7 @@ test('token in cookie only, when onlyCookie is passed to verifyJWT()', function 
         return reply.send(decodedToken)
       })
   })
-  
+
   t.test('token present in cookie', function (t) {
     t.plan(2)
     fastify.inject({
@@ -1975,7 +1975,7 @@ test('token in cookie only, when onlyCookie is passed to verifyJWT()', function 
         url: '/verify',
         cookies: {
           jwt: token + 'randomValue'
-        },
+        }
       }).then(function (verifyResponse) {
         const error = JSON.parse(verifyResponse.payload)
         t.equal(error.message, 'Authorization token is invalid: The token signature is invalid.')
@@ -1983,7 +1983,6 @@ test('token in cookie only, when onlyCookie is passed to verifyJWT()', function 
       })
     })
   })
-
 })
 
 test('token in cookie, with @fastify/cookie parsing', function (t) {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1877,6 +1877,115 @@ test('token in a signed cookie, with @fastify/cookie parsing', function (t) {
   })
 })
 
+test('token in cookie only, when onlyCookie is passed to verifyJWT()', function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  fastify.register(jwt, { secret: 'test', cookie: { cookieName: 'jwt' } })
+  fastify.register(require('@fastify/cookie'))
+
+  fastify.post('/sign', function (request, reply) {
+    return reply.jwtSign(request.body)
+      .then(function (token) {
+        return { token }
+      })
+  })
+
+  fastify.get('/verify', function (request, reply) {
+    return request.jwtVerify({ onlyCookie: true })
+      .then(function (decodedToken) {
+        return reply.send(decodedToken)
+      })
+  })
+  
+  t.test('token present in cookie', function (t) {
+    t.plan(2)
+    fastify.inject({
+      method: 'post',
+      url: '/sign',
+      payload: { foo: 'bar' }
+    }).then(function (signResponse) {
+      const token = JSON.parse(signResponse.payload).token
+      t.ok(token)
+
+      return fastify.inject({
+        method: 'get',
+        url: '/verify',
+        cookies: {
+          jwt: token
+        }
+      }).then(function (verifyResponse) {
+        const decodedToken = JSON.parse(verifyResponse.payload)
+        t.equal(decodedToken.foo, 'bar')
+      })
+    })
+  })
+
+  t.test('token absent in cookie', function (t) {
+    t.plan(2)
+    fastify.inject({
+      method: 'get',
+      url: '/verify',
+      cookies: {}
+    }).then(function (verifyResponse) {
+      const error = JSON.parse(verifyResponse.payload)
+      t.equal(error.message, 'No Authorization was found in request.cookies')
+      t.equal(error.statusCode, 401)
+    })
+  })
+
+  // should reject
+  t.test('authorization headers present but no cookie header. should reject as we only check for cookie header', function (t) {
+    t.plan(3)
+    fastify.inject({
+      method: 'post',
+      url: '/sign',
+      payload: { foo: 'bar' }
+    }).then(function (signResponse) {
+      const token = JSON.parse(signResponse.payload).token
+      t.ok(token)
+
+      return fastify.inject({
+        method: 'get',
+        url: '/verify',
+        headers: {
+          authorization: token
+        }
+      }).then(function (verifyResponse) {
+        const error = JSON.parse(verifyResponse.payload)
+        t.equal(error.message, 'No Authorization was found in request.cookies')
+        t.equal(error.statusCode, 401)
+      })
+    })
+  })
+
+  // check here 1
+  t.test('malformed cookie header, should reject', function (t) {
+    t.plan(3)
+    fastify.inject({
+      method: 'post',
+      url: '/sign',
+      payload: { foo: 'bar' }
+    }).then(function (signResponse) {
+      const token = JSON.parse(signResponse.payload).token
+      t.ok(token)
+
+      return fastify.inject({
+        method: 'get',
+        url: '/verify',
+        cookies: {
+          jwt: token + 'randomValue'
+        },
+      }).then(function (verifyResponse) {
+        const error = JSON.parse(verifyResponse.payload)
+        t.equal(error.message, 'Authorization token is invalid: The token signature is invalid.')
+        t.equal(error.statusCode, 401)
+      })
+    })
+  })
+
+})
+
 test('token in cookie, with @fastify/cookie parsing', function (t) {
   t.plan(6)
 

--- a/test/types/jwt.test-d.ts
+++ b/test/types/jwt.test-d.ts
@@ -37,7 +37,8 @@ const jwtOptions: FastifyJWTOptions = {
   },
   verify: {
     maxAge: '1 hour',
-    extractToken: (request) => 'token'
+    extractToken: (request) => 'token',
+    onlyCookie: false
   },
   decode: {
     complete: true


### PR DESCRIPTION
Fork of https://github.com/fastify/fastify-jwt/pull/263 with added type test

Closes https://github.com/fastify/fastify-jwt/pull/263 and https://github.com/fastify/fastify-jwt/pull/260

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
