### PR TITLE
perf: allow-list only needed files for packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/fastify/fastify-jwt/issues"
   },
   "homepage": "https://github.com/fastify/fastify-jwt#readme",
+  "files": ["*.js", "*.d.ts"],
   "dependencies": {
     "@fastify/error": "^3.0.0",
     "@lukeed/ms": "^2.0.0",


### PR DESCRIPTION
In this small patch I add a short allowList to the `package.json` file, to ensure that only essential files are added to the distributed package.

- The package in its compressed form goes down from 24538 bytes to 13863 bytes (around 41% less)
- In its decompressed form, goes from 163.9kB to 57.5kB (around 65% less)

It can be checked by running `npm pack` and inspecting the generated artifacts.

Signed-off-by: Andres Correa Casablanca <castarco@coderspirit.xyz>

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included: **(does not apply)**
- [x] documentation is changed or added: **(does not apply)**
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
