### PR TITLE
fix: handle fast-jwt decode error properly

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -203,17 +203,16 @@ function fastifyJwt (fastify, options, next) {
     try {
       return selectedDecoder(token)
     } catch (error) {
+      // Ignoring the else branch because it's not possible to test it,
+      // it's just a safeguard for future changes in the fast-jwt library
+      /* istanbul ignore next */
       if (error.code === TokenError.codes.malformed) {
         throw new AuthorizationTokenInvalidError(error.message)
-      }
-
-      // istanbul ignore next. false positive: i don't know why this is not covered
-      if (error.code === TokenError.codes.invalidType) {
+      } else if (error.code === TokenError.codes.invalidType) {
         throw new AuthorizationTokenInvalidError(error.message)
+      } else {
+        throw error
       }
-
-      // istanbul ignore next. unreachable code: this should never happen
-      throw error
     }
   }
 

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1493,7 +1493,7 @@ test('decode', function (t) {
 })
 
 test('errors', function (t) {
-  t.plan(12)
+  t.plan(14)
 
   const fastify = Fastify()
   fastify.register(jwt, {


### PR DESCRIPTION
fixes #274 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
