### PR TITLE
fix: propagate user result

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -511,7 +511,7 @@ function fastifyJwt (fastify, options, next) {
             maybePromise
               .then(trusted => trusted ? callback(null, result) : callback(new AuthorizationTokenUntrustedError()))
           } else if (maybePromise) {
-            callback(null, maybePromise)
+            callback(null, result)
           } else {
             callback(new AuthorizationTokenUntrustedError())
           }

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1357,13 +1357,15 @@ test('sign and verify with RSA/ECDSA certificates and global options', function 
 test('sign and verify with trusted token', function (t) {
   t.plan(2)
   t.test('Trusted token verification', function (t) {
-    t.plan(1)
+    t.plan(2)
 
     const f = Fastify()
     f.register(jwt, { secret: 'test', trusted: (request, { jti }) => jti !== 'untrusted' })
     f.get('/', (request, reply) => {
       request.jwtVerify()
         .then(function (decodedToken) {
+          delete decodedToken?.iat
+          t.same(decodedToken, { foo: 'bar', jti: 'trusted' })
           return reply.send(decodedToken)
         })
         .catch(function (error) {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1387,13 +1387,15 @@ test('sign and verify with trusted token', function (t) {
   })
 
   t.test('Trusted token - async verification', function (t) {
-    t.plan(1)
+    t.plan(2)
 
     const f = Fastify()
     f.register(jwt, { secret: 'test', trusted: (request, { jti }) => Promise.resolve(jti !== 'untrusted') })
     f.get('/', (request, reply) => {
       request.jwtVerify()
         .then(function (decodedToken) {
+          delete decodedToken?.iat
+          t.same(decodedToken, { foo: 'bar', jti: 'trusted' })
           return reply.send(decodedToken)
         })
         .catch(function (error) {


### PR DESCRIPTION
when you set the `trusted` option, if the function return a boolean `true`, it will be set as `request.user` value instead of the decrypted token.

This behaviour was already working for the async style - added an assertion for it