### PR TITLE
fix: handle fast-jwt verify error properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,8 +454,12 @@ const fastify = require('fastify')
 
 const myCustomMessages = {
   badRequestErrorMessage: 'Format is Authorization: Bearer [token]',
+  badCookieRequestErrorMessage: 'Cookie could not be parsed in request',
   noAuthorizationInHeaderMessage: 'Autorization header is missing!',
+  noAuthorizationInCookieMessage: 'No Authorization was found in request.cookies',
   authorizationTokenExpiredMessage: 'Authorization token expired',
+  authorizationTokenUntrusted: 'Untrusted authorization token',
+  authorizationTokenUnsigned: 'Unsigned authorization token
   // for the below message you can pass a sync function that must return a string as shown or a string
   authorizationTokenInvalid: (err) => {
     return `Authorization token is invalid: ${err.message}`

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -118,6 +118,7 @@ declare namespace fastifyJwt {
       authorizationTokenExpiredMessage?: string
       authorizationTokenInvalid?: ((err: Error) => string) | string
       authorizationTokenUntrusted?: string
+      authorizationTokenUnsigned?: string
     }
     trusted?: (request: FastifyRequest, decodedToken: { [k: string]: any }) => boolean | Promise<boolean> | SignPayloadType | Promise<SignPayloadType>
     formatUser?: (payload: SignPayloadType) => UserType,

--- a/jwt.js
+++ b/jwt.js
@@ -14,7 +14,8 @@ const messages = {
   noAuthorizationInCookieMessage: 'No Authorization was found in request.cookies',
   authorizationTokenExpiredMessage: 'Authorization token expired',
   authorizationTokenInvalid: (err) => `Authorization token is invalid: ${err.message}`,
-  authorizationTokenUntrusted: 'Untrusted authorization token'
+  authorizationTokenUntrusted: 'Untrusted authorization token',
+  authorizationTokenUnsigned: 'Unsigned authorization token'
 }
 
 function wrapStaticSecretInCallback (secret) {
@@ -109,6 +110,7 @@ function fastifyJwt (fastify, options, next) {
   const NoAuthorizationInCookieError = createError('FST_JWT_NO_AUTHORIZATION_IN_COOKIE', messagesOptions.noAuthorizationInCookieMessage, 401)
   const AuthorizationTokenExpiredError = createError('FST_JWT_AUTHORIZATION_TOKEN_EXPIRED', messagesOptions.authorizationTokenExpiredMessage, 401)
   const AuthorizationTokenUntrustedError = createError('FST_JWT_AUTHORIZATION_TOKEN_UNTRUSTED', messagesOptions.authorizationTokenUntrusted, 401)
+  const AuthorizationTokenUnsignedError = createError('FAST_JWT_MISSING_SIGNATURE', messagesOptions.authorizationTokenUnsigned, 401)
   const NoAuthorizationInHeaderError = createError('FST_JWT_NO_AUTHORIZATION_IN_HEADER', messagesOptions.noAuthorizationInHeaderMessage, 401)
   const AuthorizationTokenInvalidError = createError('FST_JWT_AUTHORIZATION_TOKEN_INVALID', typeof messagesOptions.authorizationTokenInvalid === 'function'
     ? messagesOptions.authorizationTokenInvalid({ message: '%s' })
@@ -496,6 +498,10 @@ function fastifyJwt (fastify, options, next) {
             return callback(typeof messagesOptions.authorizationTokenInvalid === 'function'
               ? new AuthorizationTokenInvalidError(error.message)
               : new AuthorizationTokenInvalidError())
+          }
+
+          if (error.code === TokenError.codes.missingSignature) {
+            return callback(new AuthorizationTokenUnsignedError())
           }
 
           return callback(error)


### PR DESCRIPTION
fixes #281 

#### Checklist

- [x] run `npm run test` and ~~`npm run benchmark`~~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
