### PR TITLE
feat: Verifiy-only mode (pubkey-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ Function based `secret` is supported by the `request.jwtVerify()` and `reply.jwt
 
 #### Verify-only mode
 
-In cases when your incoming JWT tokens are issued by some trusted external
+In cases where your incoming JWT tokens are issued by a trusted external
 service, and you need only to verify their signature without issuing, there is
 an option to configure `fastify-jwt` in *verify-only* mode by passing the
 `secret` object containing only a public key: `{ public }`.
 
-When only a public key provided, decode and verification functions will work as
+When only a public key is provided, decode and verification functions will work as
 described below, but an exception will be thrown at an attempt to use any form
 of `sign` functionality.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ In this object `{ private, public }` the `public` key is a string or buffer cont
 
 Function based `secret` is supported by the `request.jwtVerify()` and `reply.jwtSign()` methods and is called with `request`, `token`, and `callback` parameters.
 
+#### Verify-only mode
+
+In cases when your incoming JWT tokens are issued by some trusted external
+service, and you need only to verify their signature without issuing, there is
+an option to configure `fastify-jwt` in *verify-only* mode by passing the
+`secret` object containing only a public key: `{ public }`.
+
+When only a public key provided, decode and verification functions will work as
+described below, but an exception will be thrown at an attempt to use any form
+of `sign` functionality.
+
 #### Example
 ```js
 const { readFileSync } = require('fs')
@@ -165,10 +176,18 @@ fastify.register(jwt, {
   },
   sign: { algorithm: 'ES256' }
 })
+// secret as an object with RSA public key
+// fastify-jwt is configured in VERIFY-ONLY mode
+fastify.register(jwt, {
+  secret: {
+    public: process.env.JWT_ISSUER_PUBKEY
+  }
+})
 ```
-Optionally you can define global default options that will be used by `@fastify/jwt` API if you do not override them.
 
-Additionally, it is also possible to reject tokens selectively (i.e. blacklisting) by providing the option `trusted` with the following signature: `(request, decodedToken) => boolean|Promise<boolean>|SignPayloadType|Promise<SignPayloadType>` where `request` is a `FastifyRequest` and `decodedToken` is the parsed (and verified) token information. Its result should be `false` or `Promise<false>` if the token should be rejected or, otherwise, be `true` or `Promise<true>` if the token should be accepted and, considering that `request.user` will be used after that, the return should be `decodedToken` itself.
+### Default options
+
+Optionally you can define global default options that will be used by `@fastify/jwt` API if you do not override them.
 
 #### Example
 ```js
@@ -356,6 +375,8 @@ fastify.listen({ port: 3000 }, err => {
 
 ### `trusted`
 
+Additionally, it is also possible to reject tokens selectively (i.e. blacklisting) by providing the option `trusted` with the following signature: `(request, decodedToken) => boolean|Promise<boolean>|SignPayloadType|Promise<SignPayloadType>` where `request` is a `FastifyRequest` and `decodedToken` is the parsed (and verified) token information. Its result should be `false` or `Promise<false>` if the token should be rejected or, otherwise, be `true` or `Promise<true>` if the token should be accepted and, considering that `request.user` will be used after that, the return should be `decodedToken` itself.
+
 #### Example trusted tokens
 ```js
 const fastify = require('fastify')()
@@ -534,7 +555,7 @@ fastify.jwt.verify(token, (err, decoded) => {
 ```
 
 ### fastify.jwt.decode(token [,options])
-This method is used to decode the provided token. It accepts a token (as a `Buffer` or a `string`) and returns the payload or the sections of the token. 
+This method is used to decode the provided token. It accepts a token (as a `Buffer` or a `string`) and returns the payload or the sections of the token.
 `options` must be an `Object` and can contain [decode](#decode) options.
 Can only be used synchronously.
 

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -102,12 +102,14 @@ declare namespace fastifyJwt {
   }
 
   export interface FastifyJWTOptions {
-    secret: Secret | { public: Secret; private: Secret }
+    secret: Secret | {public: Secret; private?: Secret}
     decode?: Partial<DecoderOptions>
     sign?: Partial<SignOptions>
-    verify?: Partial<VerifyOptions> & { extractToken?: (request: FastifyRequest) => string | void }
+    verify?: Partial<VerifyOptions> & {
+      extractToken?: (request: FastifyRequest) => string | void
+    }
     cookie?: {
-      cookieName: string,
+      cookieName: string
       signed: boolean
     }
     messages?: {
@@ -120,8 +122,11 @@ declare namespace fastifyJwt {
       authorizationTokenUntrusted?: string
       authorizationTokenUnsigned?: string
     }
-    trusted?: (request: FastifyRequest, decodedToken: { [k: string]: any }) => boolean | Promise<boolean> | SignPayloadType | Promise<SignPayloadType>
-    formatUser?: (payload: SignPayloadType) => UserType,
+    trusted?: (
+      request: FastifyRequest,
+      decodedToken: {[k: string]: any}
+    ) => boolean | Promise<boolean> | SignPayloadType | Promise<SignPayloadType>
+    formatUser?: (payload: SignPayloadType) => UserType
     jwtDecode?: boolean | string
     namespace?: string
     jwtVerify?: string


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Implementation of verify-only mode, discussed in https://github.com/fastify/fastify-jwt/issues/273.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
