### PR TITLE
feat: unconditionally decorate request with jwtDecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,13 @@ fastify.get("/", async (request, reply) => {
 
 ### `namespace`
 
-To define multiple JWT validators on the same routes, you may use the `namespace` option.
-You can combine this with custom names for `jwtVerify` and `jwtSign`.
+To define multiple JWT validators on the same routes, you may use the
+`namespace` option. You can combine this with custom names for `jwtVerify`,
+`jwtDecode`, and `jwtSign`.
 
-When you omit the `jwtVerify` and `jwtSign` options, the default function name will be `<namespace>JwtVerify` and `<namespace>JwtSign`.
+When you omit the `jwtVerify`, `jwtDecode`, or `jwtSign` options, the default
+function name will be `<namespace>JwtVerify`, `<namespace>JwtDecode` and
+`<namespace>JwtSign` correspondingly.
 
 #### Example with namespace
 
@@ -445,12 +448,16 @@ const fastify = require('fastify')
 fastify.register(jwt, {
   secret: 'test',
   namespace: 'security',
+  // will decorate request with `securityVerify`, `securitySign`,
+  // and default `securityJwtDecode` since no custom alias provided
   jwtVerify: 'securityVerify',
   jwtSign: 'securitySign'
 })
 
 fastify.register(jwt, {
   secret: 'fastify',
+  // will decorate request with default `airDropJwtVerify`, `airDropJwtSign`,
+  // and `airDropJwtDecode` since no custom aliases provided
   namespace: 'airDrop'
 })
 
@@ -642,9 +649,7 @@ For your convenience, `request.jwtVerify()` will look for the token in the cooki
 
 ### request.jwtDecode([options,] callback)
 
-Decode a JWT without verifying
-
-As of 3.2.0, decorated when `options.jwtDecode` is truthy. Will become non-conditionally decorated in 4.0.0. This avoid breaking change that would effect fastify-auth0-verify.
+Decode a JWT without verifying.
 
 `options` must be an `Object` and can contain `verify` and `decode` options.
 

--- a/jwt.d.ts
+++ b/jwt.d.ts
@@ -127,7 +127,7 @@ declare namespace fastifyJwt {
       decodedToken: {[k: string]: any}
     ) => boolean | Promise<boolean> | SignPayloadType | Promise<SignPayloadType>
     formatUser?: (payload: SignPayloadType) => UserType
-    jwtDecode?: boolean | string
+    jwtDecode?: string
     namespace?: string
     jwtVerify?: string
     jwtSign?: string

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -35,7 +35,7 @@ test('export', function (t) {
 })
 
 test('register', function (t) {
-  t.plan(20)
+  t.plan(17)
 
   t.test('Expose jwt methods', function (t) {
     t.plan(8)
@@ -47,39 +47,6 @@ test('register', function (t) {
         cookieName: 'token',
         signed: false
       }
-    })
-
-    fastify.get('/methods', function (request, reply) {
-      t.notOk(request.jwtDecode)
-      t.ok(request.jwtVerify)
-      t.ok(reply.jwtSign)
-    })
-
-    fastify.ready(function () {
-      t.ok(fastify.jwt.decode)
-      t.ok(fastify.jwt.options)
-      t.ok(fastify.jwt.sign)
-      t.ok(fastify.jwt.verify)
-      t.ok(fastify.jwt.cookie)
-    })
-
-    fastify.inject({
-      method: 'get',
-      url: '/methods'
-    })
-  })
-
-  t.test('Expose jwt methods - 3.x.x conditional jwtDecode', function (t) {
-    t.plan(8)
-
-    const fastify = Fastify()
-    fastify.register(jwt, {
-      secret: 'test',
-      cookie: {
-        cookieName: 'token',
-        signed: false
-      },
-      jwtDecode: true
     })
 
     fastify.get('/methods', function (request, reply) {
@@ -283,80 +250,6 @@ test('register', function (t) {
         }
       }).ready(function (error) {
         t.equal(error, undefined)
-      })
-    })
-  })
-
-  t.test('RS/ES algorithm in sign options and secret as string', function (t) {
-    t.plan(2)
-
-    t.test('RS algorithm (Must return an error)', function (t) {
-      t.plan(1)
-
-      const fastify = Fastify()
-      fastify.register(jwt, {
-        secret: 'test',
-        sign: {
-          algorithm: 'RS256',
-          aud: 'Some audience',
-          iss: 'Some issuer',
-          sub: 'Some subject'
-        }
-      }).ready(function (error) {
-        t.equal(error.message, 'RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
-      })
-    })
-
-    t.test('ES algorithm (Must return an error)', function (t) {
-      t.plan(1)
-      const fastify = Fastify()
-      fastify.register(jwt, {
-        secret: 'test',
-        sign: {
-          algorithm: 'ES256',
-          aud: 'Some audience',
-          iss: 'Some issuer',
-          sub: 'Some subject'
-        }
-      }).ready(function (error) {
-        t.equal(error.message, 'ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
-      })
-    })
-  })
-
-  t.test('RS/ES algorithm in sign options and secret as a Buffer', function (t) {
-    t.plan(2)
-
-    t.test('RS algorithm (Must return an error)', function (t) {
-      t.plan(1)
-
-      const fastify = Fastify()
-      fastify.register(jwt, {
-        secret: Buffer.from('some secret', 'base64'),
-        sign: {
-          algorithm: 'RS256',
-          aud: 'Some audience',
-          iss: 'Some issuer',
-          sub: 'Some subject'
-        }
-      }).ready(function (error) {
-        t.equal(error.message, 'RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
-      })
-    })
-
-    t.test('ES algorithm (Must return an error)', function (t) {
-      t.plan(1)
-      const fastify = Fastify()
-      fastify.register(jwt, {
-        secret: Buffer.from('some secret', 'base64'),
-        sign: {
-          algorithm: 'ES256',
-          aud: 'Some audience',
-          iss: 'Some issuer',
-          sub: 'Some subject'
-        }
-      }).ready(function (error) {
-        t.equal(error.message, 'ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
       })
     })
   })
@@ -2718,7 +2611,7 @@ test('expose decode token for plugin extension', function (t) {
   t.plan(3)
 
   const fastify = Fastify()
-  fastify.register(jwt, { secret: 'test', jwtDecode: true })
+  fastify.register(jwt, { secret: 'test' })
 
   fastify.post('/sign', async function (request, reply) {
     const token = await reply.jwtSign(request.body)
@@ -2814,7 +2707,7 @@ test('support extended config contract', function (t) {
   }
 
   const fastify = Fastify()
-  fastify.register(jwt, { secret: 'test', jwtDecode: true })
+  fastify.register(jwt, { secret: 'test' })
 
   fastify.post('/sign', async function (request, reply) {
     const token = await reply.jwtSign(request.body, extConfig)
@@ -2955,8 +2848,7 @@ test('supporting time definitions for "maxAge", "expiresIn" and "notBefore"', as
     },
     decode: {
       complete: true
-    },
-    jwtDecode: true
+    }
   }
 
   const oneDayInSeconds = 24 * 60 * 60
@@ -3066,8 +2958,7 @@ test('global user options should not be modified', async function (t) {
     },
     decode: {
       complete: true
-    },
-    jwtDecode: true
+    }
   }
 
   const fastify = Fastify()

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -16,18 +16,17 @@ test('Unable to add the namespace twice', function (t) {
 
 test('multiple namespace', async function (t) {
   const fastify = Fastify()
-  fastify.register(jwt, { namespace: 'aaa', secret: 'test', verify: { extractToken: (request) => request.headers.customauthheader }, jwtDecode: true })
+  fastify.register(jwt, { namespace: 'aaa', secret: 'test', verify: { extractToken: (request) => request.headers.customauthheader } })
   fastify.register(jwt, { namespace: 'bbb', secret: 'sea', verify: { extractToken: (request) => request.headers.customauthheader }, jwtVerify: 'verifyCustom', jwtSign: 'signCustom', jwtDecode: 'decodeCustom' })
-  fastify.register(jwt, { namespace: 'ccc', secret: 'tset', verify: { extractToken: (request) => request.headers.customauthheader } })
 
   fastify.post('/sign/:namespace', async function (request, reply) {
     switch (request.params.namespace) {
       case 'aaa':
         return reply.aaaJwtSign(request.body)
-      case 'ccc':
-        return reply.cccJwtSign(request.body)
-      default:
+      case 'bbb':
         return reply.signCustom(request.body)
+      default:
+        reply.code(501).send({ message: `Namespace ${request.params.namespace} is not implemented correctly` })
     }
   })
 
@@ -35,19 +34,19 @@ test('multiple namespace', async function (t) {
     switch (request.params.namespace) {
       case 'aaa':
         return request.aaaJwtVerify()
-      default:
+      case 'bbb':
         return request.verifyCustom()
+      default:
+        reply.code(501).send({ message: `Namespace ${request.params.namespace} is not implemented correctly` })
     }
   })
 
   fastify.get('/decode/:namespace', async function (request, reply) {
     switch (request.params.namespace) {
       case 'aaa':
-        return request.jwtDecode()
+        return request.aaaJwtDecode()
       case 'bbb':
         return request.decodeCustom()
-      case 'ccc':
-        return request.cccJwtDecode()
       default:
         reply.code(501).send({ message: `Namespace ${request.params.namespace} is not implemented correctly` })
     }
@@ -93,14 +92,6 @@ test('multiple namespace', async function (t) {
   const tokenB = signResponse.payload
   t.ok(tokenB)
 
-  signResponse = await fastify.inject({
-    method: 'post',
-    url: '/sign/ccc',
-    payload: { foo: 'tset' }
-  })
-  const tokenC = signResponse.payload
-  t.ok(tokenC)
-
   verifyResponse = await fastify.inject({
     method: 'get',
     url: '/verify/bbb',
@@ -139,14 +130,4 @@ test('multiple namespace', async function (t) {
   })
   t.equal(verifyResponseBBB.statusCode, 200)
   t.match(verifyResponseBBB.json(), { foo: 'sky' })
-
-  const verifyResponseCCC = await fastify.inject({
-    method: 'get',
-    url: '/decode/ccc',
-    headers: {
-      customauthheader: tokenC
-    }
-  })
-  t.equal(verifyResponseCCC.statusCode, 200)
-  t.match(verifyResponseCCC.json(), { foo: 'tset' })
 })

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,0 +1,172 @@
+'use strict'
+
+const test = require('tap').test
+const Fastify = require('fastify')
+const jwt = require('../jwt')
+
+test('Options validation', function (t) {
+  t.plan(3)
+
+  t.test('Options are required', function (t) {
+    t.plan(1)
+
+    const fastify = Fastify()
+    fastify.register(jwt).ready((error) => {
+      t.equal(error.message, 'missing secret')
+    })
+  })
+
+  t.test('Request method aliases', function (t) {
+    t.plan(6)
+
+    t.test('jwtDecode fail', function (t) {
+      t.plan(1)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'sec',
+        jwtDecode: true
+      }).ready((error) => {
+        t.equal(error.message, 'Invalid options.jwtDecode')
+      })
+    })
+
+    t.test('jwtDecode success', function (t) {
+      t.plan(1)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'sec',
+        jwtDecode: 'hello'
+      }).ready((error) => {
+        t.error(error)
+      })
+    })
+
+    t.test('jwtVerify fail', function (t) {
+      t.plan(1)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'sec',
+        jwtVerify: 123
+      }).ready((error) => {
+        t.equal(error.message, 'Invalid options.jwtVerify')
+      })
+    })
+
+    t.test('jwtVerify success', function (t) {
+      t.plan(1)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'sec',
+        jwtVerify: String('hello')
+      }).ready((error) => {
+        t.error(error)
+      })
+    })
+
+    t.test('jwtSign fail', function (t) {
+      t.plan(1)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'sec',
+        jwtSign: {}
+      }).ready((error) => {
+        t.equal(error && error.message, 'Invalid options.jwtSign')
+      })
+    })
+
+    t.test('jwtSign success', function (t) {
+      t.plan(1)
+
+      const fastify = Fastify()
+      fastify.register(jwt, {
+        secret: 'sec',
+        jwtSign: ''
+      }).ready((error) => {
+        t.error(error)
+      })
+    })
+  })
+
+  t.test('Secret formats', function (t) {
+    t.plan(2)
+
+    t.test('RS/ES algorithm in sign options and secret as string', function (t) {
+      t.plan(2)
+
+      t.test('RS algorithm (Must return an error)', function (t) {
+        t.plan(1)
+
+        const fastify = Fastify()
+        fastify.register(jwt, {
+          secret: 'test',
+          sign: {
+            algorithm: 'RS256',
+            aud: 'Some audience',
+            iss: 'Some issuer',
+            sub: 'Some subject'
+          }
+        }).ready(function (error) {
+          t.equal(error && error.message, 'RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+        })
+      })
+
+      t.test('ES algorithm (Must return an error)', function (t) {
+        t.plan(1)
+        const fastify = Fastify()
+        fastify.register(jwt, {
+          secret: 'test',
+          sign: {
+            algorithm: 'ES256',
+            aud: 'Some audience',
+            iss: 'Some issuer',
+            sub: 'Some subject'
+          }
+        }).ready(function (error) {
+          t.equal(error && error.message, 'ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+        })
+      })
+    })
+
+    t.test('RS/ES algorithm in sign options and secret as a Buffer', function (t) {
+      t.plan(2)
+
+      t.test('RS algorithm (Must return an error)', function (t) {
+        t.plan(1)
+
+        const fastify = Fastify()
+        fastify.register(jwt, {
+          secret: Buffer.from('some secret', 'base64'),
+          sign: {
+            algorithm: 'RS256',
+            aud: 'Some audience',
+            iss: 'Some issuer',
+            sub: 'Some subject'
+          }
+        }).ready(function (error) {
+          t.equal(error.message, 'RSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+        })
+      })
+
+      t.test('ES algorithm (Must return an error)', function (t) {
+        t.plan(1)
+        const fastify = Fastify()
+        fastify.register(jwt, {
+          secret: Buffer.from('some secret', 'base64'),
+          sign: {
+            algorithm: 'ES256',
+            aud: 'Some audience',
+            iss: 'Some issuer',
+            sub: 'Some subject'
+          }
+        }).ready(function (error) {
+          t.equal(error.message, 'ECDSA Signatures set as Algorithm in the options require a private and public key to be set as the secret')
+        })
+      })
+    })
+  })
+})

--- a/test/types/jwt.test-d.ts
+++ b/test/types/jwt.test-d.ts
@@ -61,7 +61,6 @@ const jwtOptions: FastifyJWTOptions = {
         : payload;
     return { name: objectPayload.userName }
   },
-  jwtDecode: true,
   namespace: 'security',
   jwtVerify: 'securityVerify',
   jwtSign: 'securitySign'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

https://github.com/fastify/fastify-jwt/issues/295

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
