### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ of `sign` functionality.
 
 #### Example
 ```js
-const { readFileSync } = require('fs')
-const path = require('path')
+const { readFileSync } = require('node:fs')
+const path = require('node:path')
 const fastify = require('fastify')()
 const jwt = require('@fastify/jwt')
 // secret as a string
@@ -191,8 +191,8 @@ Optionally you can define global default options that will be used by `@fastify/
 
 #### Example
 ```js
-const { readFileSync } = require('fs')
-const path = require('path')
+const { readFileSync } = require('node:fs')
+const path = require('node:path')
 const fastify = require('fastify')()
 const jwt = require('@fastify/jwt')
 fastify.register(jwt, {
@@ -640,8 +640,8 @@ For your convenience, the `decode`, `sign`, `verify` and `messages` options you 
 
 #### Example
 ```js
-const { readFileSync } = require('fs')
-const path = require('path')
+const { readFileSync } = require('node:fs')
+const path = require('node:path')
 const fastify = require('fastify')()
 const jwt = require('@fastify/jwt')
 fastify.register(jwt, {

--- a/example/UsingCertificates.md
+++ b/example/UsingCertificates.md
@@ -12,7 +12,7 @@ openssl rsa -in private.key -out public.key -outform PEM -pubout
 Code example
 
 ```js
-const { readFileSync } = require('fs')
+const { readFileSync } = require('node:fs')
 const fastify = require('fastify')()
 const jwt = require('@fastify/jwt')
 
@@ -41,7 +41,7 @@ openssl rsa -in private.pem -outform PEM -pubout -out public.pem
 Code example
 
 ```js
-const { readFileSync } = require('fs')
+const { readFileSync } = require('node:fs')
 const fastify = require('fastify')()
 const jwt = require('@fastify/jwt')
 
@@ -72,7 +72,7 @@ openssl ec -in privateECDSA.key -pubout -out publicECDSA.key
 Code example
 
 ```js
-const { readFileSync } = require('fs')
+const { readFileSync } = require('node:fs')
 const fastify = require('fastify')()
 const jwt = require('@fastify/jwt')
 
@@ -101,7 +101,7 @@ openssl ec -in privateECDSA.pem -pubout -out publicECDSA.pem
 Code example
 
 ```js
-const { readFileSync } = require('fs')
+const { readFileSync } = require('node:fs')
 const fastify = require('fastify')()
 const jwt = require('@fastify/jwt')
 

--- a/jwt.js
+++ b/jwt.js
@@ -2,7 +2,7 @@
 
 const fp = require('fastify-plugin')
 const { createSigner, createDecoder, createVerifier, TokenError } = require('fast-jwt')
-const assert = require('assert')
+const assert = require('node:assert')
 const steed = require('steed')
 const { parse } = require('@lukeed/ms')
 const createError = require('@fastify/error')

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 
 function generateKeyPair () {
   const options = {


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
