### PR TITLE
fix: local sign options overwrites global sign options

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -369,12 +369,12 @@ function fastifyJwt (fastify, options, next) {
       const localSignOptions = convertTemporalProps(options.sign)
       // New supported contract, options supports sign and can expand
       options = {
-        sign: mergeOptionsWithKey(Object.assign({ ...signOptions }, localSignOptions), true)
+        sign: mergeOptionsWithKey(Object.assign({}, signOptions, localSignOptions), true)
       }
     } else {
       const localOptions = convertTemporalProps(options)
       // Original contract, options supports only sign
-      options = mergeOptionsWithKey(Object.assign({ ...signOptions }, localOptions), true)
+      options = mergeOptionsWithKey(Object.assign({}, signOptions, localOptions), true)
     }
 
     if (!payload) {

--- a/jwt.js
+++ b/jwt.js
@@ -369,12 +369,12 @@ function fastifyJwt (fastify, options, next) {
       const localSignOptions = convertTemporalProps(options.sign)
       // New supported contract, options supports sign and can expand
       options = {
-        sign: mergeOptionsWithKey(Object.assign(signOptions, localSignOptions), true)
+        sign: mergeOptionsWithKey(Object.assign({ ...signOptions }, localSignOptions), true)
       }
     } else {
       const localOptions = convertTemporalProps(options)
       // Original contract, options supports only sign
-      options = mergeOptionsWithKey(Object.assign(signOptions, localOptions), true)
+      options = mergeOptionsWithKey(Object.assign({ ...signOptions }, localOptions), true)
     }
 
     if (!payload) {


### PR DESCRIPTION
Closes #304 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
