### PR TITLE
test: use t.error

### DIFF
--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -78,7 +78,7 @@ test('register', function (t) {
         public: publicKey
       }
     }).ready(function (error) {
-      t.equal(error, undefined)
+      t.error(error)
     })
   })
 
@@ -88,7 +88,7 @@ test('register', function (t) {
     fastify.register(jwt, {
       secret: Buffer.from('some secret', 'base64')
     }).ready(function (error) {
-      t.equal(error, undefined)
+      t.error(error)
     })
   })
 
@@ -98,7 +98,7 @@ test('register', function (t) {
     fastify.register(jwt, {
       secret: (request, token, callback) => { callback(null, Buffer.from('some secret', 'base64')) }
     }).ready(function (error) {
-      t.equal(error, undefined)
+      t.error(error)
     })
   })
 
@@ -108,7 +108,7 @@ test('register', function (t) {
     fastify.register(jwt, {
       secret: (request, token) => Promise.resolve(Buffer.from('some secret', 'base64'))
     }).ready(function (error) {
-      t.equal(error, undefined)
+      t.error(error)
     })
   })
 
@@ -118,7 +118,7 @@ test('register', function (t) {
     fastify.register(jwt, {
       secret: async (request, token) => Buffer.from('some secret', 'base64')
     }).ready(function (error) {
-      t.equal(error, undefined)
+      t.error(error)
     })
   })
 
@@ -172,7 +172,7 @@ test('register', function (t) {
           sub: 'Some subject'
         }
       }).ready(function (error) {
-        t.equal(error, undefined)
+        t.error(error)
       })
     })
   })
@@ -194,7 +194,7 @@ test('register', function (t) {
         allowedAud: 'Some audience'
       }
     }).ready(function (error) {
-      t.equal(error, undefined)
+      t.error(error)
     })
   })
 
@@ -223,7 +223,7 @@ test('register', function (t) {
           allowedSub: 'Some subject'
         }
       }).ready(function (error) {
-        t.equal(error, undefined)
+        t.error(error)
       })
     })
 
@@ -249,7 +249,7 @@ test('register', function (t) {
           allowedSub: 'Some subject'
         }
       }).ready(function (error) {
-        t.equal(error, undefined)
+        t.error(error)
       })
     })
   })


### PR DESCRIPTION
Detected by my citgm worfklow

I guess we now return null instead of undefined, so the tests fail. Fixing this. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
