### PR TITLE
Ignore authorization headers if not Bearer

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -240,15 +240,12 @@ function fastifyJwt (fastify, options, next) {
       if (!token) {
         throw new BadRequestError()
       }
-    } else if ((request.headers && request.headers.authorization) && (!onlyCookie)) {
+    } else if ((request.headers && request.headers.authorization && /^Bearer/i.test(request.headers.authorization)) && (!onlyCookie)) {
+      
       const parts = request.headers.authorization.split(' ')
       if (parts.length === 2) {
         const scheme = parts[0]
         token = parts[1]
-
-        if (!/^Bearer$/i.test(scheme)) {
-          throw new BadRequestError()
-        }
       } else {
         throw new BadRequestError()
       }

--- a/jwt.js
+++ b/jwt.js
@@ -240,7 +240,7 @@ function fastifyJwt (fastify, options, next) {
       if (!token) {
         throw new BadRequestError()
       }
-    } else if ((request.headers && request.headers.authorization && /^Bearer/i.test(request.headers.authorization)) && (!onlyCookie)) {
+    } else if (request.headers?.authorization && /^Bearer\s/i.test(request.headers.authorization) && !onlyCookie) {
       const parts = request.headers.authorization.split(' ')
       if (parts.length === 2) {
         token = parts[1]

--- a/jwt.js
+++ b/jwt.js
@@ -243,7 +243,6 @@ function fastifyJwt (fastify, options, next) {
     } else if ((request.headers && request.headers.authorization && /^Bearer/i.test(request.headers.authorization)) && (!onlyCookie)) {
       const parts = request.headers.authorization.split(' ')
       if (parts.length === 2) {
-        const scheme = parts[0]
         token = parts[1]
       } else {
         throw new BadRequestError()

--- a/jwt.js
+++ b/jwt.js
@@ -240,7 +240,7 @@ function fastifyJwt (fastify, options, next) {
       if (!token) {
         throw new BadRequestError()
       }
-    } else if (request.headers?.authorization && /^Bearer\s/i.test(request.headers.authorization) && !onlyCookie) {
+    } else if (request.headers.authorization && !onlyCookie && /^Bearer\s/i.test(request.headers.authorization)) {
       const parts = request.headers.authorization.split(' ')
       if (parts.length === 2) {
         token = parts[1]

--- a/jwt.js
+++ b/jwt.js
@@ -241,7 +241,6 @@ function fastifyJwt (fastify, options, next) {
         throw new BadRequestError()
       }
     } else if ((request.headers && request.headers.authorization && /^Bearer/i.test(request.headers.authorization)) && (!onlyCookie)) {
-      
       const parts = request.headers.authorization.split(' ')
       if (parts.length === 2) {
         const scheme = parts[0]

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1617,20 +1617,19 @@ test('errors', function (t) {
           t.equal(response.statusCode, 401)
         })
       })
-
-      t.test('authorization header format error', function (t) {
+      t.test('no bearer authorization header error', function (t) {
         t.plan(2)
 
         fastify.inject({
           method: 'get',
           url: '/verify',
           headers: {
-            authorization: 'Invalid Format'
+            authorization: 'Another Format'
           }
         }).then(function (response) {
           const error = JSON.parse(response.payload)
-          t.equal(error.message, 'Format is Authorization: Bearer [token]')
-          t.equal(response.statusCode, 400)
+          t.equal(error.message, 'No Authorization was found in request.headers')
+          t.equal(response.statusCode, 401)
         })
       })
 
@@ -2390,12 +2389,12 @@ test('custom response messages', function (t) {
           method: 'get',
           url: '/verify',
           headers: {
-            authorization: 'Invalid Format'
+            authorization: 'Another Format'
           }
         }).then(function (response) {
           const error = JSON.parse(response.payload)
-          t.equal(error.message, 'Format is Authorization: Bearer [token]')
-          t.equal(response.statusCode, 400)
+          t.equal(error.message, 'auth header missing')
+          t.equal(response.statusCode, 401)
         })
       })
 

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1624,7 +1624,7 @@ test('errors', function (t) {
           method: 'get',
           url: '/verify',
           headers: {
-            authorization: 'Another Format'
+            authorization: 'Invalid Format'
           }
         }).then(function (response) {
           const error = JSON.parse(response.payload)
@@ -2389,7 +2389,7 @@ test('custom response messages', function (t) {
           method: 'get',
           url: '/verify',
           headers: {
-            authorization: 'Another Format'
+            authorization: 'Invalid Format'
           }
         }).then(function (response) {
           const error = JSON.parse(response.payload)

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -2195,7 +2195,7 @@ test('token in cookie, with @fastify/cookie parsing', function (t) {
   })
 
   t.test('both authorization and cookie headers present, header malformed', function (t) {
-    t.plan(3)
+    t.plan(2)
     fastify.inject({
       method: 'post',
       url: '/sign',
@@ -2214,9 +2214,8 @@ test('token in cookie, with @fastify/cookie parsing', function (t) {
           authorization: 'BearerX'
         }
       }).then(function (verifyResponse) {
-        const error = JSON.parse(verifyResponse.payload)
-        t.equal(error.message, 'Format is Authorization: Bearer [token]')
-        t.equal(error.statusCode, 400)
+        const decodedToken = JSON.parse(verifyResponse.payload)
+        t.equal(decodedToken.foo, 'bar')
       })
     })
   })


### PR DESCRIPTION
Fixes: https://github.com/fastify/fastify-jwt/issues/318

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

![Screenshot 2024-01-05 155257](https://github.com/fastify/fastify-jwt/assets/1267846/a01978d1-1709-46ef-ad41-9becfeb9f219)
