### PR TITLE
fix: Async key provider and errors should be resolved internally -- dynamic JWTs in tests

### DIFF
--- a/jwt.js
+++ b/jwt.js
@@ -487,34 +487,21 @@ function fastifyJwt (fastify, options, next) {
       },
       function verify (secretOrPublicKey, callback) {
         try {
+          let verifyResult
           if (useLocalVerifier) {
             const verifierOptions = mergeOptionsWithKey(options.verify || options, secretOrPublicKey)
             const localVerifier = createVerifier(verifierOptions)
-            const verifyResult = localVerifier(token)
-            callback(null, verifyResult)
+            verifyResult = localVerifier(token)
           } else {
-            const verifyResult = verifier(token)
+            verifyResult = verifier(token)
+          }
+          if (verifyResult && typeof verifyResult.then === 'function') {
+            verifyResult.then(result => callback(null, result), error => wrapError(error, callback))
+          } else {
             callback(null, verifyResult)
           }
         } catch (error) {
-          if (error.code === TokenError.codes.expired) {
-            return callback(new AuthorizationTokenExpiredError())
-          }
-
-          if (error.code === TokenError.codes.invalidKey ||
-              error.code === TokenError.codes.invalidSignature ||
-              error.code === TokenError.codes.invalidClaimValue
-          ) {
-            return callback(typeof messagesOptions.authorizationTokenInvalid === 'function'
-              ? new AuthorizationTokenInvalidError(error.message)
-              : new AuthorizationTokenInvalidError())
-          }
-
-          if (error.code === TokenError.codes.missingSignature) {
-            return callback(new AuthorizationTokenUnsignedError())
-          }
-
-          return callback(error)
+          return wrapError(error, callback)
         }
       },
       function checkIfIsTrusted (result, callback) {
@@ -542,6 +529,27 @@ function fastifyJwt (fastify, options, next) {
         next(null, user)
       }
     })
+  }
+
+  function wrapError (error, callback) {
+    if (error.code === TokenError.codes.expired) {
+      return callback(new AuthorizationTokenExpiredError())
+    }
+
+    if (error.code === TokenError.codes.invalidKey ||
+        error.code === TokenError.codes.invalidSignature ||
+        error.code === TokenError.codes.invalidClaimValue
+    ) {
+      return callback(typeof messagesOptions.authorizationTokenInvalid === 'function'
+        ? new AuthorizationTokenInvalidError(error.message)
+        : new AuthorizationTokenInvalidError())
+    }
+
+    if (error.code === TokenError.codes.missingSignature) {
+      return callback(new AuthorizationTokenUnsignedError())
+    }
+
+    return callback(error)
   }
 }
 

--- a/test/jwt-async.test.js
+++ b/test/jwt-async.test.js
@@ -33,3 +33,30 @@ test('Async key provider should be resolved internaly', async function (t) {
   t.comment("Should be 'undefined'")
   t.equal(response.payload, 'function')
 })
+
+test('Async key provider errors should be resolved internaly', async function (t) {
+  const fastify = Fastify()
+  fastify.register(jwt, {
+    secret: {
+      private: 'supersecret',
+      public: async () => false
+    },
+    verify: {
+      extractToken: (request) => request.headers.jwt,
+      key: () => Promise.resolve('supersecret')
+    }
+  })
+  fastify.get('/', async function (request, reply) {
+    request.headers.jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    await request.jwtVerify()
+    return reply.send(typeof request.user.then)
+  })
+  const response = await fastify.inject({
+    method: 'get',
+    url: '/'
+  })
+
+  t.comment('Should be 401')
+  t.equal(response.statusCode, 500)
+})

--- a/test/jwt-async.test.js
+++ b/test/jwt-async.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const test = require('tap').test
+const Fastify = require('fastify')
+const jwt = require('../jwt')
+
+test('Async key provider should be resolved internaly', async function (t) {
+  const fastify = Fastify()
+  fastify.register(jwt, {
+    secret: {
+      private: 'supersecret',
+      public: async () => false
+    },
+    verify: {
+      extractToken: (request) => request.headers.jwt,
+      key: () => Promise.resolve('supersecret')
+    }
+  })
+  fastify.get('/', async function (request, reply) {
+    const token = await reply.jwtSign({ user: 'test' })
+    request.headers.jwt = token
+    await request.jwtVerify()
+    return reply.send(typeof request.user.then)
+  })
+  const response = await fastify.inject({
+    method: 'get',
+    url: '/',
+    headers: {
+      jwt: 'supersecret'
+    }
+  })
+  t.ok(response)
+  t.comment("Should be 'undefined'")
+  t.equal(response.payload, 'function')
+})

--- a/test/jwt-async.test.js
+++ b/test/jwt-async.test.js
@@ -3,6 +3,7 @@
 const test = require('tap').test
 const Fastify = require('fastify')
 const jwt = require('../jwt')
+const { createSigner } = require('fast-jwt')
 
 test('Async key provider should be resolved internally', async function (t) {
   const fastify = Fastify()
@@ -46,8 +47,8 @@ test('Async key provider errors should be resolved internally', async function (
     }
   })
   fastify.get('/', async function (request, reply) {
-    request.headers.jwt =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    const signSync = createSigner({ key: 'invalid signature error' })
+    request.headers.jwt = signSync({ sub: '1234567890', name: 'John Doe', iat: 1516239022 })
     // call to local verifier without cache
     await request.jwtVerify()
     return reply.send(typeof request.user.then)
@@ -64,6 +65,7 @@ test('Async key provider should be resolved internally with cache', async functi
   const fastify = Fastify()
   fastify.register(jwt, {
     secret: {
+      private: 'this secret reused from cache',
       public: async () => false
     },
     verify: {
@@ -72,7 +74,8 @@ test('Async key provider should be resolved internally with cache', async functi
     }
   })
   fastify.get('/', async function (request, reply) {
-    request.headers.jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.hQOxra1Zo9z61vCqe6_86kVfLqKI0WxDnkiJ_upW0sM'
+    const signSync = createSigner({ key: 'this secret reused from cache' })
+    request.headers.jwt = signSync({ sub: '1234567890', name: 'John Doe', iat: 1516239022 })
     await new Promise((resolve, reject) => request.jwtVerify((err, payload) => {
       if (err) {
         reject(err)
@@ -109,8 +112,10 @@ test('Async key provider errors should be resolved internally with cache', async
     }
   })
   fastify.get('/', async function (request, reply) {
-    request.headers.jwt =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    const signSync = createSigner({ key: 'invalid signature error' })
+    request.headers.jwt = signSync({ sub: '1234567890', name: 'John Doe', iat: 1516239022 })
+    // request.headers.jwt =
+    //   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
     // call to plugin root level verifier
     await new Promise((resolve, reject) => request.jwtVerify((err, payload) => {
       if (err) {

--- a/test/jwt-async.test.js
+++ b/test/jwt-async.test.js
@@ -9,7 +9,7 @@ test('Async key provider should be resolved internally', async function (t) {
   fastify.register(jwt, {
     secret: {
       private: 'supersecret',
-      public: async () => false
+      public: async () => Promise.resolve('supersecret')
     },
     verify: {
       extractToken: (request) => request.headers.jwt,
@@ -20,7 +20,7 @@ test('Async key provider should be resolved internally', async function (t) {
     const token = await reply.jwtSign({ user: 'test' })
     request.headers.jwt = token
     await request.jwtVerify()
-    return reply.send(typeof request.user.then)
+    return reply.send(request.user)
   })
   const response = await fastify.inject({
     method: 'get',
@@ -31,24 +31,24 @@ test('Async key provider should be resolved internally', async function (t) {
   })
   t.ok(response)
   t.comment("Should be 'undefined'")
-  t.equal(response.payload, 'function')
+  t.match(response.json(), { user: 'test' })
 })
 
 test('Async key provider errors should be resolved internally', async function (t) {
   const fastify = Fastify()
   fastify.register(jwt, {
     secret: {
-      private: 'supersecret',
-      public: async () => false
+      public: async () => Promise.resolve('key used per request, false not allowed')
     },
     verify: {
       extractToken: (request) => request.headers.jwt,
-      key: () => Promise.resolve('supersecret')
+      key: () => Promise.resolve('key not used')
     }
   })
   fastify.get('/', async function (request, reply) {
     request.headers.jwt =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    // call to local verifier without cache
     await request.jwtVerify()
     return reply.send(typeof request.user.then)
   })
@@ -57,6 +57,74 @@ test('Async key provider errors should be resolved internally', async function (
     url: '/'
   })
 
-  t.comment('Should be 401')
-  t.equal(response.statusCode, 500)
+  t.equal(response.statusCode, 401)
+})
+
+test('Async key provider should be resolved internally with cache', async function (t) {
+  const fastify = Fastify()
+  fastify.register(jwt, {
+    secret: {
+      public: async () => false
+    },
+    verify: {
+      extractToken: (request) => request.headers.jwt,
+      key: () => Promise.resolve('this secret reused from cache')
+    }
+  })
+  fastify.get('/', async function (request, reply) {
+    request.headers.jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.hQOxra1Zo9z61vCqe6_86kVfLqKI0WxDnkiJ_upW0sM'
+    await new Promise((resolve, reject) => request.jwtVerify((err, payload) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(payload)
+    }))
+    await new Promise((resolve, reject) => request.jwtVerify((err, payload) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(payload)
+    }))
+    return reply.send(request.user)
+  })
+  const response = await fastify.inject({
+    method: 'get',
+    url: '/'
+  })
+  t.equal(response.statusCode, 200)
+  t.match(response.json(), { name: 'John Doe' })
+})
+
+test('Async key provider errors should be resolved internally with cache', async function (t) {
+  const fastify = Fastify()
+  fastify.register(jwt, {
+    secret: {
+      public: async () => false
+    },
+    verify: {
+      extractToken: (request) => request.headers.jwt,
+      key: () => Promise.resolve('this secret reused from cache')
+    }
+  })
+  fastify.get('/', async function (request, reply) {
+    request.headers.jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    // call to plugin root level verifier
+    await new Promise((resolve, reject) => request.jwtVerify((err, payload) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(payload)
+    }))
+    return reply.send(typeof request.user.then)
+  })
+  const response = await fastify.inject({
+    method: 'get',
+    url: '/'
+  })
+
+  t.equal(response.statusCode, 401)
 })

--- a/test/jwt-async.test.js
+++ b/test/jwt-async.test.js
@@ -4,7 +4,7 @@ const test = require('tap').test
 const Fastify = require('fastify')
 const jwt = require('../jwt')
 
-test('Async key provider should be resolved internaly', async function (t) {
+test('Async key provider should be resolved internally', async function (t) {
   const fastify = Fastify()
   fastify.register(jwt, {
     secret: {
@@ -34,7 +34,7 @@ test('Async key provider should be resolved internaly', async function (t) {
   t.equal(response.payload, 'function')
 })
 
-test('Async key provider errors should be resolved internaly', async function (t) {
+test('Async key provider errors should be resolved internally', async function (t) {
   const fastify = Fastify()
   fastify.register(jwt, {
     secret: {


### PR DESCRIPTION
Generates JWTs dynamically in tests as requested by @mcollina on https://github.com/fastify/fastify-jwt/pull/335.

If there's a way to apply this change to the original PR, please point me toward it and I'll do it.

This PR includes the changes @NikitaFedorov1 made for PR 335. My understanding of his comment in 335 is that he does not intend to apply the test changes requested. I just changed a few lines in his tests (commit #5) so others can get the benefit of this fix.

I broke the tests several times before getting them right, so I know they can fail. :smile: Also confirmed response bodies/error details matched those from the hard coded tokens while working on the tests.

## PR 335 description

False positive tests: [test: Async key provider errors should be resolved internally](https://github.com/fastify/fastify-jwt/pull/335/commits/2046ff5b435f16ced5d9fa3350b374041003d792)

Fix & test fix: [feat: Async key provider](https://github.com/fastify/fastify-jwt/pull/335/commits/04288be3d7702e341de8becb0abfb4374a7388e9)

Related issue: https://github.com/fastify/fastify-jwt/issues/334

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
