### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/test/options.test.js
+++ b/test/options.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const Fastify = require('fastify')
 const jwt = require('../jwt')
-const { AssertionError } = require('assert')
+const { AssertionError } = require('node:assert')
 
 test('Options validation', async function (t) {
   t.plan(3)


### PR DESCRIPTION
This is a batch PR, so may have some issues. Please review changes.