### PR TITLE
feat: add validate option to validate JWT payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,37 @@ async function validateToken(request, decodedToken) {
 }
 ```
 
+#### validateDecoded
+
+`validateDecoded` allows you to validate the decoded payload of the JWT before it is considered trusted. This is useful for custom validation logic such as checking specific claims, types, or applying JSON Schema-based validations.
+
+This function can be **synchronous** or return a **Promise**. If it throws or rejects, Fastify will return a `400 Bad Request` with the error message.
+
+```js
+fastify.register(jwt, {
+  secret: 'supersecret',
+  validateDecoded: (payload) => {
+    if (!payload.isVerified) {
+      throw new Error('User is not verified')
+    }
+  }
+})
+```
+
+You can also use an async function:
+```js
+fastify.register(jwt, {
+  secret: 'supersecret',
+  validateDecoded: async (payload) => {
+    const isAllowed = await checkInDatabase(payload.userId)
+    if (!isAllowed) {
+      throw new Error('Not allowed')
+    }
+  }
+})
+```
+
+
 ### `formatUser`
 
 #### Example with formatted user
@@ -907,6 +938,22 @@ fastify.get('/', async (request, reply) => {
   });
 })
 
+```
+
+### Token Payload Validation (`validateDecoded`)
+
+You can use the `validateDecoded` option to validate the decoded payload after the token is verified but before the request is processed.
+
+Example:
+```js
+fastify.register(require('@fastify/jwt'), {
+  secret: 'supersecret',
+  validateDecoded: async (payload) => {
+    if (!payload.role || payload.role !== 'admin') {
+      throw new Error('Token must include admin role')
+    }
+  }
+})
 ```
 
 ## Acknowledgments

--- a/jwt.js
+++ b/jwt.js
@@ -100,6 +100,7 @@ function fastifyJwt (fastify, options, next) {
     sign: initialSignOptions = {},
     trusted,
     decoratorName = 'user',
+    validate,
     // TODO: disable on next major
     // enable errorCacheTTL to prevent breaking change
     verify: initialVerifyOptions = { errorCacheTTL: 600000 },
@@ -510,6 +511,23 @@ function fastifyJwt (fastify, options, next) {
           }
         } catch (error) {
           return wrapError(error, callback)
+        }
+      },
+      function validateClaims (result, callback) {
+        if (!validate) return callback(null, result)
+
+        try {
+          const maybePromise = validate(result)
+
+          if (maybePromise?.then) {
+            maybePromise
+              .then(() => callback(null, result))
+              .catch(callback)
+          } else {
+            callback(null, result)
+          }
+        } catch (err) {
+          callback(err)
         }
       },
       function checkIfIsTrusted (result, callback) {

--- a/test/validate-option.test.js
+++ b/test/validate-option.test.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const Fastify = require('fastify')
+const jwt = require('../jwt')
+
+test('validate option - success case', async (t) => {
+  const fastify = Fastify()
+  fastify.register(jwt, {
+    secret: 'supersecret',
+    validate: (payload) => {
+      assert.equal(payload.foo, 'bar')
+    }
+  })
+
+  fastify.get('/protected', {
+    handler: async (request, reply) => {
+      await request.jwtVerify()
+      return { user: request.user }
+    }
+  })
+
+  await fastify.ready()
+
+  const token = fastify.jwt.sign({ foo: 'bar' })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/protected',
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
+
+  assert.equal(response.statusCode, 200)
+
+  const body = JSON.parse(response.body)
+  assert.equal(body.user.foo, 'bar')
+  assert.ok(body.user.iat)
+})
+
+test('validate option - should throw and block access', async (t) => {
+  const fastify = Fastify()
+  fastify.register(jwt, {
+    secret: 'supersecret',
+    validate: (payload) => {
+      if (!payload.admin) throw new Error('Unauthorized')
+    }
+  })
+
+  fastify.get('/admin', {
+    handler: async (request, reply) => {
+      await request.jwtVerify()
+      return { user: request.user }
+    }
+  })
+
+  await fastify.ready()
+
+  const token = fastify.jwt.sign({ foo: 'bar' })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/admin',
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
+
+  assert.equal(response.statusCode, 500)
+  assert.match(response.body, /Unauthorized/)
+})
+
+test('validate option - async function', async (t) => {
+  const fastify = Fastify()
+  fastify.register(jwt, {
+    secret: 'supersecret',
+    validate: async (payload) => {
+      if (!payload.verified) throw new Error('Not verified')
+    }
+  })
+
+  fastify.get('/async-check', {
+    handler: async (request, reply) => {
+      await request.jwtVerify()
+      return { user: request.user }
+    }
+  })
+
+  await fastify.ready()
+
+  const token = fastify.jwt.sign({ verified: true })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/async-check',
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
+
+  assert.equal(response.statusCode, 200)
+
+  const body = JSON.parse(response.body)
+  assert.equal(body.user.verified, true)
+  assert.ok(body.user.iat)
+})

--- a/types/jwt.d.ts
+++ b/types/jwt.d.ts
@@ -159,6 +159,7 @@ declare namespace fastifyJwt {
       decodedToken: { [k: string]: any }
     ) => boolean | Promise<boolean> | SignPayloadType | Promise<SignPayloadType>
     formatUser?: (payload: SignPayloadType) => UserType
+    validate?: (payload: Record<string, any>) => void | Promise<void>;
     jwtDecode?: string
     namespace?: string
     jwtVerify?: string

--- a/types/jwt.d.ts
+++ b/types/jwt.d.ts
@@ -159,7 +159,7 @@ declare namespace fastifyJwt {
       decodedToken: { [k: string]: any }
     ) => boolean | Promise<boolean> | SignPayloadType | Promise<SignPayloadType>
     formatUser?: (payload: SignPayloadType) => UserType
-    validate?: (payload: Record<string, any>) => void | Promise<void>;
+    validateDecoded?: (payload: Record<string, any>) => void | Promise<void>
     jwtDecode?: string
     namespace?: string
     jwtVerify?: string


### PR DESCRIPTION
This PR introduces a new validate option to the @fastify/jwt plugin. It allows developers to perform custom validation logic after the JWT is decoded and verified, before assigning request.user.

This is useful when token claims alone aren't enough, and additional logic (e.g., checking a verified flag or a role) is required.

#### Example of usage:
```
fastify.register(jwt, {
  secret: 'supersecret',
  validate: (payload) => {
    if (!payload.admin) {
      throw new Error('Not authorized')
    }
  }
})
```

#### Also supports async functions:
```
fastify.register(jwt, {
  secret: 'supersecret',
  validate: async (payload) => {
    if (!await someCheck(payload.userId)) {
      throw new Error('Blocked by validation')
    }
  }
})
```

#### Implementation
- Adds support for a validate(payload) function in the plugin options.

- Executes validate inside request.jwtVerify() after decoding/verifying the token.

- If validate throws or rejects, a 500 error is returned.

- Type definitions updated (types/jwt.d.ts) to include the new option.

#### Tests
- validate option - success case

- validate option - should throw and block access

- validate option - async function

#### Related
Closes #316 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
