### PR TITLE
update fast-jwt to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fastify/error": "^4.2.0",
     "@lukeed/ms": "^2.0.2",
-    "fast-jwt": "^6.0.2",
+    "fast-jwt": "^6.2.0",
     "fastify-plugin": "^5.0.1",
     "steed": "^1.1.3"
   },


### PR DESCRIPTION
Sets minimum version of `fast-jwt` to `6.2.0`.

Closes: #401

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
