### PR TITLE
fix: propagate errors from async trusted callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -528,7 +528,10 @@ function fastifyJwt (fastify, options, next) {
 
           if (maybePromise?.then) {
             maybePromise
-              .then(trusted => trusted ? callback(null, result) : callback(new AuthorizationTokenUntrustedError()))
+              .then(
+                trusted => trusted ? callback(null, result) : callback(new AuthorizationTokenUntrustedError()),
+                err => callback(err)
+              )
           } else if (maybePromise) {
             callback(null, result)
           } else {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1280,7 +1280,7 @@ test('sign and verify with RSA/ECDSA certificates and global options', async fun
 })
 
 test('sign and verify with trusted token', async function (t) {
-  t.plan(2)
+  t.plan(3)
   await t.test('Trusted token verification', async function (t) {
     t.plan(2)
 
@@ -1339,6 +1339,38 @@ test('sign and verify with trusted token', async function (t) {
     })
 
     t.assert.strictEqual(response.statusCode, 200)
+  })
+
+  await t.test('Trusted token - async verification rejects', async function (t) {
+    t.plan(2)
+
+    const f = Fastify()
+    f.register(jwt, {
+      secret: 'test',
+      trusted: () => Promise.reject(new Error('boom'))
+    })
+    f.get('/', (request, reply) => {
+      request.jwtVerify()
+        .then(function (decodedToken) {
+          return reply.send(decodedToken)
+        })
+        .catch(function (error) {
+          return reply.code(500).send({ message: error.message })
+        })
+    })
+
+    const signer = createSigner({ key: 'test', jti: 'trusted' })
+    const token = signer({ foo: 'bar' })
+    const response = await f.inject({
+      method: 'get',
+      url: '/',
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    })
+
+    t.assert.strictEqual(response.statusCode, 500)
+    t.assert.strictEqual(response.json().message, 'boom')
   })
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### What this PR does

When a user supplied `trusted` callback returns a rejected promise, the rejection was silently dropped. `.then(...)` had no onRejected handler, so:

* `steed.waterfall`'s final callback was never invoked and the request hung.
* The rejection surfaced as an `unhandledRejection` on the Node process.

### Fix

Pass the onRejected handler to `.then(...)` so the error flows to the waterfall's terminal callback, matching the behavior of every other step.

### Test

Added `Trusted token, async verification rejects` in `test/jwt.test.js`. It registers a `trusted` callback that returns `Promise.reject(new Error('boom'))` and asserts the error reaches the route handler (status 500, `message === 'boom'`). The test fails on `main` and passes with the fix.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added (no API or doc change, purely a bug fix)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)