### PR TITLE
feat!: unify secret function signature across all code paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,16 @@ In this object `{ private, public }` the `private` key is a string, buffer, or o
 
 In this object `{ private, public }` the `public` key is a string or buffer containing either the secret for HMAC algorithms, or the PEM encoded public key for RSA and ECDSA.
 
-Function based `secret` is supported by the `request.jwtVerify()` and `reply.jwtSign()` methods and is called with `request`, `token`, and `callback` parameters.
+Function based `secret` is supported by all methods (`request.jwtVerify()`, `reply.jwtSign()`, `fastify.jwt.sign()`, and `fastify.jwt.verify()`) and is called with a `context` object and a `callback`.
+
+The `context` object has the following shape:
+- `operation`: `'sign'` or `'verify'`
+- `payload`: the JWT payload
+- `header`: the JWT header (only for `'verify'`)
+- `signature`: the JWT signature (only for `'verify'`)
+- `request`: the Fastify request object (only available in `request.jwtVerify()` and `reply.jwtSign()`)
+
+When using a function-based secret with `fastify.jwt.sign()` or `fastify.jwt.verify()`, a callback argument is required.
 
 #### Verify-only mode
 
@@ -140,20 +149,21 @@ const jwt = require('@fastify/jwt')
 fastify.register(jwt, { secret: 'supersecret' })
 // secret as a function with callback
 fastify.register(jwt, {
-  secret: function (request, token, callback) {
-    // do something
+  secret: function (context, callback) {
+    // context.operation is 'sign' or 'verify'
+    // context.payload, context.header, context.signature, context.request
     callback(null, 'supersecret')
   }
 })
 // secret as a function returning a promise
 fastify.register(jwt, {
-  secret: function (request, token) {
+  secret: function (context) {
     return Promise.resolve('supersecret')
   }
 })
 // secret as an async function
 fastify.register(jwt, {
-  secret: async function (request, token) {
+  secret: async function (context) {
     return 'supersecret'
   }
 })
@@ -780,8 +790,8 @@ const jwt = require('@fastify/jwt')
 const request = require('request')
 
 fastify.register(jwt, {
-  secret: function (request, reply, callback) {
-    // do something
+  secret: function (context, callback) {
+    // context.operation is 'sign' or 'verify'
     callback(null, 'supersecret')
   }
 })

--- a/index.js
+++ b/index.js
@@ -27,10 +27,17 @@ function resolveSecret (secretValue, context, callback) {
     return callback(null, secretValue)
   }
 
-  const result = secretValue(context, callback)
+  let called = false
+  function once (err, val) {
+    if (called) return
+    called = true
+    callback(err, val)
+  }
+
+  const result = secretValue(context, once)
 
   if (result && typeof result.then === 'function') {
-    result.then(secret => callback(null, secret), callback)
+    result.then(secret => once(null, secret), once)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -127,9 +127,6 @@ function fastifyJwt (fastify, options, next) {
     secretOrPrivateKey = secretOrPublicKey = secret
   }
 
-  const hasStaticPublicKey = typeof secretOrPublicKey !== 'function'
-  const hasStaticPrivateKey = typeof secretOrPrivateKey !== 'function'
-
   const signOptions = convertTemporalProps(initialSignOptions)
   const verifyOptions = convertTemporalProps(initialVerifyOptions, true)
   const messagesOptions = Object.assign({}, messages, pluginOptions.messages)
@@ -190,15 +187,15 @@ function fastifyJwt (fastify, options, next) {
   fastify.decorateReply(jwtSignName, replySign)
 
   const signerConfig = checkAndMergeSignOptions()
-  // no signer when configured in verify-mode or when secret is a function
-  const signer = signerConfig.options.key
+  // no signer when configured in verify-mode or when secret is a function (resolved per-call)
+  const signer = (signerConfig.options.key && typeof signerConfig.options.key !== 'function')
     ? createSigner(signerConfig.options)
     : null
   const decoder = createDecoder(decodeOptions)
   const completeDecoder = createDecoder(Object.assign({}, decodeOptions, { complete: true }))
   const verifierConfig = checkAndMergeVerifyOptions()
   // no global verifier when secret is a function (resolved per-call)
-  const verifier = verifierConfig.options.key
+  const verifier = (verifierConfig.options.key && typeof verifierConfig.options.key !== 'function')
     ? createVerifier(verifierConfig.options)
     : null
 
@@ -207,7 +204,7 @@ function fastifyJwt (fastify, options, next) {
   function getVerifier (options, globalOptions) {
     const useGlobalOptions = globalOptions ?? options === verifierConfig.options
     // Use global verifier if using global options with static key
-    if (useGlobalOptions && hasStaticPublicKey) return verifier
+    if (useGlobalOptions && verifier) return verifier
     // Only cache verifier when using default options (except for key)
     if (useGlobalOptions && options.key && typeof options.key === 'string') {
       let verifier = validatorCache.get(options.key)
@@ -232,6 +229,8 @@ function fastifyJwt (fastify, options, next) {
     try {
       return selectedDecoder(token)
     } catch (error) {
+      // Ignoring the else branch because it's not possible to test it,
+      // it's just a safeguard for future changes in the fast-jwt library
       if (error.code === TokenError.codes.malformed) {
         throw new AuthorizationTokenInvalidError(error.message)
       } else if (error.code === TokenError.codes.invalidType) {
@@ -282,12 +281,10 @@ function fastifyJwt (fastify, options, next) {
   }
 
   function withStaticKey (options, usePrivateKey) {
+    if (options.key) return Object.assign({}, options)
     const key = usePrivateKey ? secretOrPrivateKey : secretOrPublicKey
-    if (typeof key === 'function') {
-      // Key will be resolved per-call via resolveSecret
-      return Object.assign({}, options)
-    }
-    return Object.assign(!options.key ? { key } : {}, options)
+    if (!key) return Object.assign({}, options)
+    return Object.assign({}, options, { key })
   }
 
   function withResolvedKey (options, key) {
@@ -318,7 +315,7 @@ function fastifyJwt (fastify, options, next) {
     const signerConfig = checkAndMergeSignOptions(localOptions, callback)
 
     if (typeof signerConfig.callback !== 'function') {
-      assert(hasStaticPrivateKey, 'callback is required when secret is a function')
+      assert(typeof signerConfig.options.key !== 'function', 'callback is required when secret is a function')
       let localSigner = signer
       if (options && typeof options !== 'function') {
         localSigner = createSigner(signerConfig.options)
@@ -328,7 +325,7 @@ function fastifyJwt (fastify, options, next) {
 
     const cb = signerConfig.callback
     const context = { operation: 'sign', payload }
-    resolveSecret(secretOrPrivateKey, context, function (err, secret) {
+    resolveSecret(signerConfig.options.key, context, function (err, secret) {
       if (err) return cb(err)
       const resolvedOptions = withResolvedKey(signerConfig.options, secret)
       const localSigner = createSigner(resolvedOptions)
@@ -344,7 +341,7 @@ function fastifyJwt (fastify, options, next) {
     const verifierConfig = checkAndMergeVerifyOptions(localOptions, callback)
 
     if (typeof verifierConfig.callback !== 'function') {
-      assert(hasStaticPublicKey, 'callback is required when secret is a function')
+      assert(typeof verifierConfig.options.key !== 'function', 'callback is required when secret is a function')
       let localVerifier = verifier
       if (options && typeof options !== 'function') {
         localVerifier = getVerifier(verifierConfig.options)
@@ -355,7 +352,7 @@ function fastifyJwt (fastify, options, next) {
     const cb = verifierConfig.callback
     const decoded = completeDecoder(token)
     const context = { operation: 'verify', header: decoded.header, payload: decoded.payload, signature: decoded.signature }
-    resolveSecret(secretOrPublicKey, context, function (err, secret) {
+    resolveSecret(verifierConfig.options.key, context, function (err, secret) {
       if (err) return cb(err)
       const resolvedOptions = withResolvedKey(verifierConfig.options, secret)
       const localVerifier = getVerifier(resolvedOptions)
@@ -405,14 +402,16 @@ function fastifyJwt (fastify, options, next) {
       return next(new Error('jwtSign requires a payload'))
     }
 
+    const replySignOptions = options.sign || options
+
     steed.waterfall([
       function getSecret (callback) {
         const context = { operation: 'sign', payload, request: reply.request }
-        resolveSecret(secretOrPrivateKey, context, callback)
+        resolveSecret(replySignOptions.key, context, callback)
       },
       function sign (secretOrPrivateKey, callback) {
         if (useLocalSigner) {
-          const signerOptions = withResolvedKey(options.sign || options, secretOrPrivateKey)
+          const signerOptions = withResolvedKey(replySignOptions, secretOrPrivateKey)
           const localSigner = createSigner(signerOptions)
           const token = localSigner(payload)
           callback(null, token)
@@ -487,12 +486,12 @@ function fastifyJwt (fastify, options, next) {
       // New supported contract, options supports both decode and verify
       options = {
         decode: Object.assign({}, decodeOptions, options.decode),
-        verify: Object.assign({}, verifyOptions, localVerifyOptions)
+        verify: withStaticKey(Object.assign({}, verifyOptions, localVerifyOptions), false)
       }
     } else {
       const localOptions = convertTemporalProps(options, true)
       // Original contract, options supports only verify
-      options = Object.assign({}, verifyOptions, localOptions)
+      options = withStaticKey(Object.assign({}, verifyOptions, localOptions), false)
     }
 
     let token
@@ -517,6 +516,8 @@ function fastifyJwt (fastify, options, next) {
       } /* c8 ignore stop */
     }
 
+    const requestVerifyOptions = options.verify || options
+
     steed.waterfall([
       function getSecret (callback) {
         const context = {
@@ -526,15 +527,17 @@ function fastifyJwt (fastify, options, next) {
           signature: completeDecode.signature,
           request
         }
-        resolveSecret(secretOrPublicKey, context, callback)
+        resolveSecret(requestVerifyOptions.key, context, callback)
       },
       function verify (secretOrPublicKey, callback) {
         try {
           const verifierOptions = secretOrPublicKey
-            ? withResolvedKey(options.verify || options, secretOrPublicKey)
-            : Object.assign({}, options.verify || options)
+            ? withResolvedKey(requestVerifyOptions, secretOrPublicKey)
+            /* c8 ignore next */
+            : Object.assign({}, requestVerifyOptions)
           const localVerifier = getVerifier(verifierOptions, useGlobalOptions)
           const verifyResult = localVerifier(token)
+          /* c8 ignore next 2 */
           if (verifyResult && typeof verifyResult.then === 'function') {
             verifyResult.then(result => callback(null, result), error => wrapError(error, callback))
           } else {

--- a/index.js
+++ b/index.js
@@ -22,9 +22,15 @@ function isString (x) {
   return Object.prototype.toString.call(x) === '[object String]'
 }
 
-function wrapStaticSecretInCallback (secret) {
-  return function (_request, _payload, cb) {
-    return cb(null, secret)
+function resolveSecret (secretValue, context, callback) {
+  if (typeof secretValue !== 'function') {
+    return callback(null, secretValue)
+  }
+
+  const result = secretValue(context, callback)
+
+  if (result && typeof result.then === 'function') {
+    result.then(secret => callback(null, secret), callback)
   }
 }
 
@@ -121,16 +127,8 @@ function fastifyJwt (fastify, options, next) {
     secretOrPrivateKey = secretOrPublicKey = secret
   }
 
-  let hasStaticPublicKey = false
-  let secretCallbackSign = secretOrPrivateKey
-  let secretCallbackVerify = secretOrPublicKey
-  if (typeof secretCallbackSign !== 'function') {
-    secretCallbackSign = wrapStaticSecretInCallback(secretCallbackSign)
-  }
-  if (typeof secretCallbackVerify !== 'function') {
-    secretCallbackVerify = wrapStaticSecretInCallback(secretCallbackVerify)
-    hasStaticPublicKey = true
-  }
+  const hasStaticPublicKey = typeof secretOrPublicKey !== 'function'
+  const hasStaticPrivateKey = typeof secretOrPrivateKey !== 'function'
 
   const signOptions = convertTemporalProps(initialSignOptions)
   const verifyOptions = convertTemporalProps(initialVerifyOptions, true)
@@ -192,13 +190,17 @@ function fastifyJwt (fastify, options, next) {
   fastify.decorateReply(jwtSignName, replySign)
 
   const signerConfig = checkAndMergeSignOptions()
-  // no signer when configured in verify-mode
+  // no signer when configured in verify-mode or when secret is a function
   const signer = signerConfig.options.key
     ? createSigner(signerConfig.options)
     : null
   const decoder = createDecoder(decodeOptions)
+  const completeDecoder = createDecoder(Object.assign({}, decodeOptions, { complete: true }))
   const verifierConfig = checkAndMergeVerifyOptions()
-  const verifier = createVerifier(verifierConfig.options)
+  // no global verifier when secret is a function (resolved per-call)
+  const verifier = verifierConfig.options.key
+    ? createVerifier(verifierConfig.options)
+    : null
 
   next()
 
@@ -230,8 +232,6 @@ function fastifyJwt (fastify, options, next) {
     try {
       return selectedDecoder(token)
     } catch (error) {
-      // Ignoring the else branch because it's not possible to test it,
-      // it's just a safeguard for future changes in the fast-jwt library
       if (error.code === TokenError.codes.malformed) {
         throw new AuthorizationTokenInvalidError(error.message)
       } else if (error.code === TokenError.codes.invalidType) {
@@ -281,21 +281,25 @@ function fastifyJwt (fastify, options, next) {
     return token
   }
 
-  function mergeOptionsWithKey (options, useProvidedPrivateKey) {
-    if (useProvidedPrivateKey && (typeof useProvidedPrivateKey !== 'boolean')) {
-      return Object.assign({}, options, { key: useProvidedPrivateKey })
-    } else {
-      const key = useProvidedPrivateKey ? secretOrPrivateKey : secretOrPublicKey
-      return Object.assign(!options.key ? { key } : {}, options)
+  function withStaticKey (options, usePrivateKey) {
+    const key = usePrivateKey ? secretOrPrivateKey : secretOrPublicKey
+    if (typeof key === 'function') {
+      // Key will be resolved per-call via resolveSecret
+      return Object.assign({}, options)
     }
+    return Object.assign(!options.key ? { key } : {}, options)
+  }
+
+  function withResolvedKey (options, key) {
+    return Object.assign({}, options, { key })
   }
 
   function checkAndMergeOptions (options, defaultOptions, usePrivateKey, callback) {
     if (typeof options === 'function') {
-      return { options: mergeOptionsWithKey(defaultOptions, usePrivateKey), callback: options }
+      return { options: withStaticKey(defaultOptions, usePrivateKey), callback: options }
     }
 
-    return { options: mergeOptionsWithKey(options || defaultOptions, usePrivateKey), callback }
+    return { options: withStaticKey(options || defaultOptions, usePrivateKey), callback }
   }
 
   function checkAndMergeSignOptions (options, callback) {
@@ -308,50 +312,60 @@ function fastifyJwt (fastify, options, next) {
 
   function sign (payload, options, callback) {
     assert(payload, 'missing payload')
-    // if a global signer was not created, sign mode is not supported
-    assert(signer, 'unable to sign: secret is configured in verify mode')
-
-    let localSigner = signer
+    assert(secretOrPrivateKey, 'unable to sign: secret is configured in verify mode')
 
     const localOptions = convertTemporalProps(options)
     const signerConfig = checkAndMergeSignOptions(localOptions, callback)
 
-    if (options && typeof options !== 'function') {
-      localSigner = createSigner(signerConfig.options)
-    }
-
-    if (typeof signerConfig.callback === 'function') {
-      const token = localSigner(payload)
-      signerConfig.callback(null, token)
-    } else {
+    if (typeof signerConfig.callback !== 'function') {
+      assert(hasStaticPrivateKey, 'callback is required when secret is a function')
+      let localSigner = signer
+      if (options && typeof options !== 'function') {
+        localSigner = createSigner(signerConfig.options)
+      }
       return localSigner(payload)
     }
+
+    const cb = signerConfig.callback
+    const context = { operation: 'sign', payload }
+    resolveSecret(secretOrPrivateKey, context, function (err, secret) {
+      if (err) return cb(err)
+      const resolvedOptions = withResolvedKey(signerConfig.options, secret)
+      const localSigner = createSigner(resolvedOptions)
+      cb(null, localSigner(payload))
+    })
   }
 
   function verify (token, options, callback) {
     assert(token, 'missing token')
     assert(secretOrPublicKey, 'missing secret')
 
-    let localVerifier = verifier
-
     const localOptions = convertTemporalProps(options, true)
     const verifierConfig = checkAndMergeVerifyOptions(localOptions, callback)
 
-    if (options && typeof options !== 'function') {
-      localVerifier = getVerifier(verifierConfig.options)
-    }
-
-    if (typeof verifierConfig.callback === 'function') {
-      const result = localVerifier(token)
-      verifierConfig.callback(null, result)
-    } else {
+    if (typeof verifierConfig.callback !== 'function') {
+      assert(hasStaticPublicKey, 'callback is required when secret is a function')
+      let localVerifier = verifier
+      if (options && typeof options !== 'function') {
+        localVerifier = getVerifier(verifierConfig.options)
+      }
       return localVerifier(token)
     }
+
+    const cb = verifierConfig.callback
+    const decoded = completeDecoder(token)
+    const context = { operation: 'verify', header: decoded.header, payload: decoded.payload, signature: decoded.signature }
+    resolveSecret(secretOrPublicKey, context, function (err, secret) {
+      if (err) return cb(err)
+      const resolvedOptions = withResolvedKey(verifierConfig.options, secret)
+      const localVerifier = getVerifier(resolvedOptions)
+      cb(null, localVerifier(token))
+    })
   }
 
   function replySign (payload, options, next) {
-    // if a global signer was not created, sign mode is not supported
-    assert(signer, 'unable to sign: secret is configured in verify mode')
+    // sign mode is not supported when only a public key is provided
+    assert(secretOrPrivateKey, 'unable to sign: secret is configured in verify mode')
 
     let useLocalSigner = true
     if (typeof options === 'function') {
@@ -379,12 +393,12 @@ function fastifyJwt (fastify, options, next) {
       const localSignOptions = convertTemporalProps(options.sign)
       // New supported contract, options supports sign and can expand
       options = {
-        sign: mergeOptionsWithKey(Object.assign({}, signOptions, localSignOptions), true)
+        sign: withStaticKey(Object.assign({}, signOptions, localSignOptions), true)
       }
     } else {
       const localOptions = convertTemporalProps(options)
       // Original contract, options supports only sign
-      options = mergeOptionsWithKey(Object.assign({}, signOptions, localOptions), true)
+      options = withStaticKey(Object.assign({}, signOptions, localOptions), true)
     }
 
     if (!payload) {
@@ -393,20 +407,19 @@ function fastifyJwt (fastify, options, next) {
 
     steed.waterfall([
       function getSecret (callback) {
-        const signResult = secretCallbackSign(reply.request, payload, callback)
-
-        if (signResult && typeof signResult.then === 'function') {
-          signResult.then(result => callback(null, result), callback)
-        }
+        const context = { operation: 'sign', payload, request: reply.request }
+        resolveSecret(secretOrPrivateKey, context, callback)
       },
       function sign (secretOrPrivateKey, callback) {
         if (useLocalSigner) {
-          const signerOptions = mergeOptionsWithKey(options.sign || options, secretOrPrivateKey)
+          const signerOptions = withResolvedKey(options.sign || options, secretOrPrivateKey)
           const localSigner = createSigner(signerOptions)
           const token = localSigner(payload)
           callback(null, token)
         } else {
-          const token = signer(payload)
+          const signerOptions = withResolvedKey(signerConfig.options, secretOrPrivateKey)
+          const localSigner = signer || createSigner(signerOptions)
+          const token = localSigner(payload)
           callback(null, token)
         }
       }
@@ -489,18 +502,37 @@ function fastifyJwt (fastify, options, next) {
       return next(err)
     }
 
-    const decodedToken = decode(token, options.decode || decodeOptions)
+    let completeDecode
+    try {
+      completeDecode = completeDecoder(token)
+    } catch (error) {
+      // Ignoring the else branch because it's not possible to test it,
+      // it's just a safeguard for future changes in the fast-jwt library
+      if (error.code === TokenError.codes.malformed) {
+        return next(new AuthorizationTokenInvalidError(error.message))
+      } else if (error.code === TokenError.codes.invalidType) {
+        return next(new AuthorizationTokenInvalidError(error.message))
+      } /* c8 ignore start */ else {
+        return next(error)
+      } /* c8 ignore stop */
+    }
 
     steed.waterfall([
       function getSecret (callback) {
-        const verifyResult = secretCallbackVerify(request, decodedToken, callback)
-        if (verifyResult && typeof verifyResult.then === 'function') {
-          verifyResult.then(result => callback(null, result), callback)
+        const context = {
+          operation: 'verify',
+          header: completeDecode.header,
+          payload: completeDecode.payload,
+          signature: completeDecode.signature,
+          request
         }
+        resolveSecret(secretOrPublicKey, context, callback)
       },
       function verify (secretOrPublicKey, callback) {
         try {
-          const verifierOptions = mergeOptionsWithKey(options.verify || options, secretOrPublicKey)
+          const verifierOptions = secretOrPublicKey
+            ? withResolvedKey(options.verify || options, secretOrPublicKey)
+            : Object.assign({}, options.verify || options)
           const localVerifier = getVerifier(verifierOptions, useGlobalOptions)
           const verifyResult = localVerifier(token)
           if (verifyResult && typeof verifyResult.then === 'function') {

--- a/index.js
+++ b/index.js
@@ -331,12 +331,29 @@ function fastifyJwt (fastify, options, next) {
     }
 
     const cb = signerConfig.callback
+
+    // Fast-path: reuse global signer when no custom options were passed
+    if (signer && (!options || typeof options === 'function')) {
+      try {
+        cb(null, signer(payload))
+      /* c8 ignore next 3 */
+      } catch (error) {
+        cb(error)
+      }
+      return
+    }
+
     const context = { operation: 'sign', payload }
     resolveSecret(signerConfig.options.key, context, function (err, secret) {
       if (err) return cb(err)
-      const resolvedOptions = withResolvedKey(signerConfig.options, secret)
-      const localSigner = createSigner(resolvedOptions)
-      cb(null, localSigner(payload))
+      try {
+        const resolvedOptions = withResolvedKey(signerConfig.options, secret)
+        const localSigner = createSigner(resolvedOptions)
+        cb(null, localSigner(payload))
+      /* c8 ignore next 3 */
+      } catch (error) {
+        cb(error)
+      }
     })
   }
 
@@ -357,13 +374,28 @@ function fastifyJwt (fastify, options, next) {
     }
 
     const cb = verifierConfig.callback
+
+    // Fast-path: reuse global verifier when no custom options were passed
+    if (verifier && (!options || typeof options === 'function')) {
+      try {
+        cb(null, verifier(token))
+      } catch (error) {
+        cb(error)
+      }
+      return
+    }
+
     const decoded = completeDecoder(token)
     const context = { operation: 'verify', header: decoded.header, payload: decoded.payload, signature: decoded.signature }
     resolveSecret(verifierConfig.options.key, context, function (err, secret) {
       if (err) return cb(err)
-      const resolvedOptions = withResolvedKey(verifierConfig.options, secret)
-      const localVerifier = getVerifier(resolvedOptions)
-      cb(null, localVerifier(token))
+      try {
+        const resolvedOptions = withResolvedKey(verifierConfig.options, secret)
+        const localVerifier = getVerifier(resolvedOptions)
+        cb(null, localVerifier(token))
+      } catch (error) {
+        cb(error)
+      }
     })
   }
 

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -916,6 +916,35 @@ test('sign and verify with function secret (server methods)', async function (t)
     t.assert.strictEqual(result.foo, 'bar')
   })
 
+  await t.test('sign with async function key that also calls callback does not double-invoke', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: 'global-secret'
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    // An async function that also calls the callback — only one should win
+    const keyFn = async function (_context, cb) {
+      cb(null, 'function-secret')
+      return 'function-secret'
+    }
+
+    fastify.jwt.sign({ foo: 'bar' }, { key: keyFn }, function (error, token) {
+      t.assert.ifError(error)
+      t.assert.ok(token)
+
+      const { createVerifier } = require('fast-jwt')
+      const localVerifier = createVerifier({ key: 'function-secret' })
+      const result = localVerifier(token)
+      t.assert.strictEqual(result.foo, 'bar')
+      resolve()
+    })
+    return promise
+  })
+
   await t.test('replySign with per-call static key override', async function (t) {
     const fastify = Fastify()
     fastify.register(jwt, {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -308,7 +308,7 @@ test('sign and verify with HS-secret', async function (t) {
   t.plan(2)
 
   await t.test('server methods', async function (t) {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     fastify.register(jwt, { secret: 'test' })
@@ -337,6 +337,22 @@ test('sign and verify with HS-secret', async function (t) {
           t.assert.strictEqual(decoded.foo, 'bar')
           resolve()
         })
+      })
+      return promise
+    })
+
+    await t.test('with callbacks and invalid token', function (t) {
+      t.plan(1)
+
+      const { promise, resolve } = helper.withResolvers()
+
+      const { createSigner: createLocalSigner } = require('fast-jwt')
+      const wrongSigner = createLocalSigner({ key: 'wrong-secret' })
+      const invalidToken = wrongSigner({ foo: 'bar' })
+
+      fastify.jwt.verify(invalidToken, function (error) {
+        t.assert.ok(error)
+        resolve()
       })
       return promise
     })
@@ -1913,6 +1929,67 @@ test('sign and verify with RSA/ECDSA certificates and global options', async fun
         t.assert.strictEqual(decodedToken.iss, 'test')
       })
     })
+  })
+})
+
+test('instance sign and verify honor custom options', async function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  fastify.register(jwt, { secret: 'test' })
+
+  await fastify.ready()
+
+  await t.test('sign with expiresIn option (sync)', function (t) {
+    t.plan(2)
+
+    const token = fastify.jwt.sign({ foo: 'bar' }, { expiresIn: '1d' })
+    const decoded = fastify.jwt.verify(token)
+
+    t.assert.strictEqual(decoded.foo, 'bar')
+    t.assert.strictEqual(decoded.exp - decoded.iat, 24 * 60 * 60)
+  })
+
+  await t.test('sign with expiresIn option (callback)', function (t) {
+    t.plan(3)
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, { expiresIn: '2h' }, function (error, token) {
+      t.assert.ifError(error)
+
+      const decoded = fastify.jwt.verify(token)
+      t.assert.strictEqual(decoded.foo, 'bar')
+      t.assert.strictEqual(decoded.exp - decoded.iat, 2 * 60 * 60)
+      resolve()
+    })
+    return promise
+  })
+
+  await t.test('sign with notBefore option (sync)', function (t) {
+    t.plan(2)
+
+    const token = fastify.jwt.sign({ foo: 'bar' }, { notBefore: '1h' })
+    const decoded = fastify.jwt.decode(token)
+
+    t.assert.strictEqual(decoded.foo, 'bar')
+    t.assert.strictEqual(decoded.nbf - decoded.iat, 60 * 60)
+  })
+
+  await t.test('verify with maxAge option (callback)', function (t) {
+    t.plan(1)
+
+    const { promise, resolve } = helper.withResolvers()
+
+    // Sign a token with iat in the past (beyond maxAge)
+    const pastIat = Math.floor(Date.now() / 1000) - 120
+    const token = fastify.jwt.sign({ foo: 'bar', iat: pastIat })
+
+    fastify.jwt.verify(token, { maxAge: 60 }, function (error) {
+      t.assert.ok(error)
+      resolve()
+    })
+    return promise
   })
 })
 

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -785,6 +785,248 @@ test('sign and verify with function secret (server methods)', async function (t)
     })
     return promise
   })
+
+  await t.test('sign with per-call static key override when global secret is a function', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () { return 'global-secret' }
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, { key: 'override-secret' }, function (error, token) {
+      t.assert.ifError(error)
+      t.assert.ok(token)
+
+      const { createVerifier } = require('fast-jwt')
+      const localVerifier = createVerifier({ key: 'override-secret' })
+      const result = localVerifier(token)
+      t.assert.strictEqual(result.foo, 'bar')
+      resolve()
+    })
+    return promise
+  })
+
+  await t.test('verify with per-call static key override when global secret is a function', async function (t) {
+    const { createSigner: createLocalSigner } = require('fast-jwt')
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () { return 'global-secret' }
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    const signer = createLocalSigner({ key: 'override-secret' })
+    const token = signer({ foo: 'bar' })
+
+    fastify.jwt.verify(token, { key: 'override-secret' }, function (error, result) {
+      t.assert.ifError(error)
+      t.assert.ok(result)
+      t.assert.strictEqual(result.foo, 'bar')
+      resolve()
+    })
+    return promise
+  })
+
+  await t.test('sign with per-call function key override', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: 'global-secret'
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    const keyFn = function (_context, cb) { cb(null, 'function-secret') }
+
+    fastify.jwt.sign({ foo: 'bar' }, { key: keyFn }, function (error, token) {
+      t.assert.ifError(error)
+      t.assert.ok(token)
+
+      const { createVerifier } = require('fast-jwt')
+      const localVerifier = createVerifier({ key: 'function-secret' })
+      const result = localVerifier(token)
+      t.assert.strictEqual(result.foo, 'bar')
+      resolve()
+    })
+    return promise
+  })
+
+  await t.test('verify with per-call function key override', async function (t) {
+    const { createSigner: createLocalSigner } = require('fast-jwt')
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: 'global-secret'
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    const signer = createLocalSigner({ key: 'function-secret' })
+    const token = signer({ foo: 'bar' })
+
+    const keyFn = function (_context, cb) { cb(null, 'function-secret') }
+
+    fastify.jwt.verify(token, { key: keyFn }, function (error, result) {
+      t.assert.ifError(error)
+      t.assert.ok(result)
+      t.assert.strictEqual(result.foo, 'bar')
+      resolve()
+    })
+    return promise
+  })
+
+  await t.test('sign sync with per-call static key when global secret is a function', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () { return 'global-secret' }
+    })
+
+    await fastify.ready()
+
+    const token = fastify.jwt.sign({ foo: 'bar' }, { key: 'override-secret' })
+    t.assert.ok(token)
+
+    const { createVerifier } = require('fast-jwt')
+    const localVerifier = createVerifier({ key: 'override-secret' })
+    const result = localVerifier(token)
+    t.assert.strictEqual(result.foo, 'bar')
+  })
+
+  await t.test('verify sync with per-call static key when global secret is a function', async function (t) {
+    const { createSigner: createLocalSigner } = require('fast-jwt')
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () { return 'global-secret' }
+    })
+
+    await fastify.ready()
+
+    const signer = createLocalSigner({ key: 'override-secret' })
+    const token = signer({ foo: 'bar' })
+
+    const result = fastify.jwt.verify(token, { key: 'override-secret' })
+    t.assert.ok(result)
+    t.assert.strictEqual(result.foo, 'bar')
+  })
+
+  await t.test('replySign with per-call static key override', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () { return 'global-secret' }
+    })
+
+    fastify.post('/sign', async function (request, reply) {
+      const token = await reply.jwtSign(request.body, { sign: { key: 'override-secret' } })
+      return { token }
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({
+      method: 'post',
+      url: '/sign',
+      payload: { foo: 'bar' }
+    })
+
+    const result = JSON.parse(response.payload)
+    t.assert.ok(result.token)
+
+    const { createVerifier } = require('fast-jwt')
+    const localVerifier = createVerifier({ key: 'override-secret' })
+    const decoded = localVerifier(result.token)
+    t.assert.strictEqual(decoded.foo, 'bar')
+  })
+
+  await t.test('replySign with per-call function key override', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: 'global-secret'
+    })
+
+    fastify.post('/sign', async function (request, reply) {
+      const keyFn = function (_context, cb) { cb(null, 'function-secret') }
+      const token = await reply.jwtSign(request.body, { sign: { key: keyFn } })
+      return { token }
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({
+      method: 'post',
+      url: '/sign',
+      payload: { foo: 'bar' }
+    })
+
+    const result = JSON.parse(response.payload)
+    t.assert.ok(result.token)
+
+    const { createVerifier } = require('fast-jwt')
+    const localVerifier = createVerifier({ key: 'function-secret' })
+    const decoded = localVerifier(result.token)
+    t.assert.strictEqual(decoded.foo, 'bar')
+  })
+
+  await t.test('requestVerify with per-call static key override', async function (t) {
+    const { createSigner: createLocalSigner } = require('fast-jwt')
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () { return 'global-secret' }
+    })
+
+    fastify.get('/verify', async function (request) {
+      return request.jwtVerify({ verify: { key: 'override-secret' } })
+    })
+
+    await fastify.ready()
+
+    const signer = createLocalSigner({ key: 'override-secret' })
+    const token = signer({ foo: 'bar' })
+
+    const response = await fastify.inject({
+      method: 'get',
+      url: '/verify',
+      headers: { authorization: `Bearer ${token}` }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    const result = JSON.parse(response.payload)
+    t.assert.strictEqual(result.foo, 'bar')
+  })
+
+  await t.test('requestVerify with per-call function key override', async function (t) {
+    const { createSigner: createLocalSigner } = require('fast-jwt')
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: 'global-secret'
+    })
+
+    fastify.get('/verify', async function (request) {
+      const keyFn = function (_context, cb) { cb(null, 'function-secret') }
+      return request.jwtVerify({ verify: { key: keyFn } })
+    })
+
+    await fastify.ready()
+
+    const signer = createLocalSigner({ key: 'function-secret' })
+    const token = signer({ foo: 'bar' })
+
+    const response = await fastify.inject({
+      method: 'get',
+      url: '/verify',
+      headers: { authorization: `Bearer ${token}` }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    const result = JSON.parse(response.payload)
+    t.assert.strictEqual(result.foo, 'bar')
+  })
 })
 
 test('sign and verify with RSA/ECDSA certificates and global options', async function (t) {
@@ -3251,7 +3493,7 @@ test('supporting time definitions for "maxAge", "expiresIn" and "notBefore"', as
 
     const token = JSON.parse(signResponse.payload).token
     t.assert.ok(token)
-    fastify.jwt.verify(token, { secret: 'test' }, (err, result) => {
+    fastify.jwt.verify(token, (err, result) => {
       t.assert.ifError(err)
       t.assert.ok(result)
       t.assert.ok(result.exp)

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -90,7 +90,7 @@ test('register', async function (t) {
   await t.test('secret as a function with a callback returning a Buffer', async function (t) {
     const fastify = Fastify()
     await fastify.register(jwt, {
-      secret: (_request, _token, callback) => { callback(null, Buffer.from('some secret', 'base64')) }
+      secret: (_context, callback) => { callback(null, Buffer.from('some secret', 'base64')) }
     }).ready()
   })
 
@@ -260,7 +260,7 @@ test('register', async function (t) {
   }
 
   await t.test('secret as a function with callback', t => {
-    return runWithSecret(t, function (_request, _token, callback) {
+    return runWithSecret(t, function (_context, callback) {
       callback(null, 'some-secret')
     })
   })
@@ -278,7 +278,7 @@ test('register', async function (t) {
   })
 
   await t.test('secret as a function with callback returning a Buffer', t => {
-    return runWithSecret(t, function (_request, _token, callback) {
+    return runWithSecret(t, function (_context, callback) {
       callback(null, Buffer.from('some-secret', 'base64'))
     })
   })
@@ -418,6 +418,372 @@ test('sign and verify with HS-secret', async function (t) {
       const decodedToken = JSON.parse(verifyResponse.payload)
       t.assert.strictEqual(decodedToken.foo, 'bar')
     })
+  })
+})
+
+test('sign and verify with function secret (server methods)', async function (t) {
+  await t.test('with callback secret', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        cb(null, 'test-secret')
+      }
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
+      t.assert.ifError(error)
+      t.assert.ok(token)
+
+      fastify.jwt.verify(token, function (error, decoded) {
+        t.assert.ifError(error)
+        t.assert.strictEqual(decoded.foo, 'bar')
+        resolve()
+      })
+    })
+    return promise
+  })
+
+  await t.test('with async secret', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () {
+        return 'test-secret'
+      }
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
+      t.assert.ifError(error)
+      t.assert.ok(token)
+
+      fastify.jwt.verify(token, function (error, decoded) {
+        t.assert.ifError(error)
+        t.assert.strictEqual(decoded.foo, 'bar')
+        resolve()
+      })
+    })
+    return promise
+  })
+
+  await t.test('sign context has operation and payload', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        t.assert.strictEqual(context.operation, 'sign')
+        t.assert.deepStrictEqual(context.payload, { foo: 'bar' })
+        t.assert.strictEqual(context.request, undefined)
+        t.assert.strictEqual(context.header, undefined)
+        t.assert.strictEqual(context.signature, undefined)
+        cb(null, 'test-secret')
+      }
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
+      t.assert.ifError(error)
+      t.assert.ok(token)
+      resolve()
+    })
+    return promise
+  })
+
+  await t.test('verify context has operation and full decoded token', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        if (context.operation === 'sign') {
+          return cb(null, 'test-secret')
+        }
+        t.assert.strictEqual(context.operation, 'verify')
+        t.assert.ok(context.header)
+        t.assert.strictEqual(context.payload.foo, 'bar')
+        t.assert.strictEqual(typeof context.payload.iat, 'number')
+        t.assert.ok(context.signature)
+        t.assert.strictEqual(context.request, undefined)
+        cb(null, 'test-secret')
+      }
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
+      t.assert.ifError(error)
+
+      fastify.jwt.verify(token, function (error, decoded) {
+        t.assert.ifError(error)
+        t.assert.strictEqual(decoded.foo, 'bar')
+        resolve()
+      })
+    })
+    return promise
+  })
+
+  await t.test('requestVerify context includes request', async function (t) {
+    const fastify = Fastify()
+    let verifyContext = null
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        if (context.operation === 'verify') {
+          verifyContext = context
+        }
+        cb(null, 'test-secret')
+      }
+    })
+
+    fastify.get('/verify', function (request) {
+      return request.jwtVerify()
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
+      t.assert.ifError(error)
+
+      fastify.inject({
+        method: 'get',
+        url: '/verify',
+        headers: { authorization: `Bearer ${token}` }
+      }).then(function (response) {
+        const decoded = JSON.parse(response.payload)
+        t.assert.strictEqual(decoded.foo, 'bar')
+        t.assert.ok(verifyContext)
+        t.assert.strictEqual(verifyContext.operation, 'verify')
+        t.assert.ok(verifyContext.request)
+        t.assert.ok(verifyContext.header)
+        t.assert.strictEqual(verifyContext.payload.foo, 'bar')
+        t.assert.strictEqual(typeof verifyContext.payload.iat, 'number')
+        t.assert.ok(verifyContext.signature)
+        resolve()
+      })
+    })
+    return promise
+  })
+
+  await t.test('replySign context includes request', async function (t) {
+    const fastify = Fastify()
+    let signContext = null
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        if (context.operation === 'sign') {
+          signContext = context
+        }
+        cb(null, 'test-secret')
+      }
+    })
+
+    fastify.post('/sign', async function (request, reply) {
+      const token = await reply.jwtSign(request.body)
+      return { token }
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({
+      method: 'post',
+      url: '/sign',
+      payload: { foo: 'bar' }
+    })
+
+    const result = JSON.parse(response.payload)
+    t.assert.ok(result.token)
+    t.assert.ok(signContext)
+    t.assert.strictEqual(signContext.operation, 'sign')
+    t.assert.ok(signContext.request)
+    t.assert.deepStrictEqual(signContext.payload, { foo: 'bar' })
+  })
+
+  await t.test('replySign context shape', async function (t) {
+    const fastify = Fastify()
+    let signContext = null
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        if (context.operation === 'sign') {
+          signContext = context
+        }
+        cb(null, 'test-secret')
+      }
+    })
+
+    fastify.post('/sign', async function (request, reply) {
+      const token = await reply.jwtSign(request.body)
+      return { token }
+    })
+
+    await fastify.ready()
+
+    await fastify.inject({
+      method: 'post',
+      url: '/sign',
+      payload: { foo: 'bar' }
+    })
+
+    t.assert.ok(signContext)
+    t.assert.strictEqual(signContext.operation, 'sign')
+    t.assert.deepStrictEqual(signContext.payload, { foo: 'bar' })
+    t.assert.ok(signContext.request)
+    t.assert.strictEqual(signContext.request.method, 'POST')
+    t.assert.strictEqual(signContext.header, undefined)
+    t.assert.strictEqual(signContext.signature, undefined)
+  })
+
+  await t.test('requestVerify context shape', async function (t) {
+    const fastify = Fastify()
+    let verifyContext = null
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        if (context.operation === 'verify') {
+          verifyContext = context
+        }
+        cb(null, 'test-secret')
+      }
+    })
+
+    fastify.get('/verify', function (request) {
+      return request.jwtVerify()
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, function (error, token) {
+      t.assert.ifError(error)
+
+      fastify.inject({
+        method: 'get',
+        url: '/verify',
+        headers: { authorization: `Bearer ${token}` }
+      }).then(function (response) {
+        t.assert.strictEqual(response.statusCode, 200)
+        t.assert.ok(verifyContext)
+        t.assert.strictEqual(verifyContext.operation, 'verify')
+        t.assert.strictEqual(verifyContext.payload.foo, 'bar')
+        t.assert.strictEqual(typeof verifyContext.payload.iat, 'number')
+        t.assert.strictEqual(verifyContext.header.alg, 'HS256')
+        t.assert.strictEqual(verifyContext.header.typ, 'JWT')
+        t.assert.strictEqual(typeof verifyContext.signature, 'string')
+        t.assert.ok(verifyContext.request)
+        t.assert.strictEqual(verifyContext.request.method, 'GET')
+        resolve()
+      })
+    })
+    return promise
+  })
+
+  await t.test('replySign with callback and function secret', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        cb(null, 'test-secret')
+      }
+    })
+
+    fastify.post('/sign', function (request, reply) {
+      reply.jwtSign(request.body, function (error, token) {
+        return reply.send(error || { token })
+      })
+    })
+
+    await fastify.ready()
+
+    const response = await fastify.inject({
+      method: 'post',
+      url: '/sign',
+      payload: { foo: 'bar' }
+    })
+
+    const result = JSON.parse(response.payload)
+    t.assert.ok(result.token)
+
+    const decoded = fastify.jwt.decode(result.token)
+    t.assert.strictEqual(decoded.foo, 'bar')
+  })
+
+  await t.test('sign requires callback when secret is a function', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () { return 'test-secret' }
+    })
+
+    await fastify.ready()
+
+    t.assert.throws(function () {
+      fastify.jwt.sign({ foo: 'bar' })
+    }, { message: 'callback is required when secret is a function' })
+  })
+
+  await t.test('verify requires callback when secret is a function', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: async function () { return 'test-secret' }
+    })
+
+    await fastify.ready()
+
+    t.assert.throws(function () {
+      fastify.jwt.verify('some-token')
+    }, { message: 'callback is required when secret is a function' })
+  })
+
+  await t.test('sign propagates errors from secret function', async function (t) {
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: function (_context, cb) {
+        cb(new Error('secret fetch failed'))
+      }
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    fastify.jwt.sign({ foo: 'bar' }, function (error) {
+      t.assert.ok(error)
+      t.assert.strictEqual(error.message, 'secret fetch failed')
+      resolve()
+    })
+    return promise
+  })
+
+  await t.test('verify propagates errors from secret function', async function (t) {
+    const { createSigner: createLocalSigner } = require('fast-jwt')
+    const fastify = Fastify()
+    fastify.register(jwt, {
+      secret: function (context, cb) {
+        if (context.operation === 'sign') {
+          return cb(null, 'test-secret')
+        }
+        cb(new Error('secret fetch failed'))
+      }
+    })
+
+    await fastify.ready()
+
+    const { promise, resolve } = helper.withResolvers()
+
+    const signer = createLocalSigner({ key: 'test-secret' })
+    const token = signer({ foo: 'bar' })
+
+    fastify.jwt.verify(token, function (error) {
+      t.assert.ok(error)
+      t.assert.strictEqual(error.message, 'secret fetch failed')
+      resolve()
+    })
+    return promise
   })
 })
 
@@ -1343,7 +1709,7 @@ test('sign and verify with trusted token', async function (t) {
 })
 
 test('decode', async function (t) {
-  t.plan(2)
+  t.plan(4)
 
   await t.test('without global options', async function (t) {
     t.plan(2)
@@ -1416,6 +1782,33 @@ test('decode', async function (t) {
       t.assert.strictEqual(decoded.signature, undefined)
       t.assert.strictEqual(decoded.foo, 'bar')
     })
+  })
+
+  await t.test('malformed token error', async function (t) {
+    t.plan(1)
+
+    const fastify = Fastify()
+    fastify.register(jwt, { secret: 'test' })
+
+    await fastify.ready()
+
+    t.assert.throws(function () {
+      fastify.jwt.decode('not-a-jwt-token')
+    }, { code: 'FST_JWT_AUTHORIZATION_TOKEN_INVALID' })
+  })
+
+  await t.test('invalid type token error', async function (t) {
+    t.plan(1)
+
+    const fastify = Fastify()
+    fastify.register(jwt, { secret: 'test', decode: { checkTyp: 'JWT' } })
+
+    await fastify.ready()
+
+    // Token with typ: "JWR" instead of "JWT"
+    t.assert.throws(function () {
+      fastify.jwt.decode('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUiJ9.e30.ha5mKb-6aDOVHh5lRaUBNdDmMAYLOl1no3LQkV2mAMQ')
+    }, { code: 'FST_JWT_AUTHORIZATION_TOKEN_INVALID' })
   })
 })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -108,11 +108,25 @@ declare namespace fastifyJwt {
     ? T
     : SignPayloadType
 
-  export type TokenOrHeader = JwtHeader | { header: JwtHeader; payload: any }
+  export interface SecretContextVerify {
+    operation: 'verify'
+    header: JwtHeader
+    payload: any
+    signature: string
+    request?: FastifyRequest
+  }
+
+  export interface SecretContextSign {
+    operation: 'sign'
+    payload: any
+    request?: FastifyRequest
+  }
+
+  export type SecretContext = SecretContextVerify | SecretContextSign
 
   export type Secret = string | Buffer | KeyFetcher | { key: Secret; passphrase: string }
-    | ((request: FastifyRequest, tokenOrHeader: TokenOrHeader, cb: (e: Error | null, secret: string | Buffer | undefined) => void) => void)
-    | ((request: FastifyRequest, tokenOrHeader: TokenOrHeader) => Promise<string | Buffer>)
+    | ((context: SecretContext, cb: (e: Error | null, secret: string | Buffer | undefined) => void) => void)
+    | ((context: SecretContext) => Promise<string | Buffer>)
 
   export type VerifyPayloadType = object | string
   export type DecodePayloadType = object | string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -135,16 +135,20 @@ declare namespace fastifyJwt {
     (err: Error, decoded: Decoded): void
   }
 
+  export type KeyOption = string | Buffer
+    | ((context: SecretContext, cb: (e: Error | null, secret: string | Buffer | undefined) => void) => void)
+    | ((context: SecretContext) => Promise<string | Buffer>)
+
   export interface SignOptions extends Omit<SignerOptions, 'expiresIn' | 'notBefore'> {
     expiresIn: number | string;
     notBefore: number | string;
-    key?: string | Buffer
+    key?: KeyOption
   }
 
   export interface VerifyOptions extends Omit<VerifierOptions, 'maxAge'> {
     maxAge: number | string;
     onlyCookie: boolean;
-    key?: string | Buffer
+    key?: KeyOption
   }
 
   export interface FastifyJWTOptions {

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -15,19 +15,19 @@ const secretOptions = {
     public: 'publicKey',
     private: 'privateKey'
   },
-  secretFnCallback: (_req: any, _token: any, cb: any) => { cb(null, 'supersecret') },
-  secretFnPromise: (_req: any, _token: any) => Promise.resolve('supersecret'),
-  secretFnAsync: async (_req: any, _token: any) => 'supersecret',
-  secretFnBufferCallback: (_req: any, _token: any, cb: any) => { cb(null, Buffer.from('some secret', 'base64')) },
-  secretFnBufferPromise: (_req: any, _token: any) => Promise.resolve(Buffer.from('some secret', 'base64')),
-  secretFnBufferAsync: async (_req: any, _token: any) => Buffer.from('some secret', 'base64'),
+  secretFnCallback: (_context: any, cb: any) => { cb(null, 'supersecret') },
+  secretFnPromise: (_context: any) => Promise.resolve('supersecret'),
+  secretFnAsync: async (_context: any) => 'supersecret',
+  secretFnBufferCallback: (_context: any, cb: any) => { cb(null, Buffer.from('some secret', 'base64')) },
+  secretFnBufferPromise: (_context: any) => Promise.resolve(Buffer.from('some secret', 'base64')),
+  secretFnBufferAsync: async (_context: any) => Buffer.from('some secret', 'base64'),
   publicPrivateKeyFn: {
-    public: (_req: any, _rep: any, cb: any) => { cb(null, 'publicKey') },
+    public: (_context: any, cb: any) => { cb(null, 'publicKey') },
     private: 'privateKey'
   },
   publicPrivateKeyFn2: {
     public: 'publicKey',
-    private: (_req: any, _rep: any, cb: any) => { cb(null, 'privateKey') },
+    private: (_context: any, cb: any) => { cb(null, 'privateKey') },
   }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The secret function signature is now called with (context, callback) where context is { operation, payload, header?, signature?, request? } instead of the previous inconsistent signatures (request, token, callback) or (request, payload).

This PR fixes #388, by changing how secret is handled - especially when it's a function. This happens in three ways:
- resolve secret before calling fast-jwt (specific fix for #388)
- uniform signature for the secret function across request and instance level functions: I propose to just pass a context object as first parameter, which will include the payload (always present) and an optional request (when called from request level methods and a request context is present)
- uniform signature for the secret function when called from either sign or verify - making the difference explicit by adding an operation attribute to the context. The other difference is that when called from a sign function, the context will be missing header and signature

Tests have been added to cover function being called on instances, and checks for the various context options.

_Disclaimer: Claude Opus was used to assist development

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
