### PR TITLE
fix: validate signed cookie signature and catch decode errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,15 @@ function fastifyJwt (fastify, options, next) {
         if (request.cookies[cookie.cookieName]) {
           const tokenValue = request.cookies[cookie.cookieName]
 
-          token = cookie.signed ? request.unsignCookie(tokenValue).value : tokenValue
+          if (cookie.signed) {
+            const { valid, value } = request.unsignCookie(tokenValue)
+            if (!valid) {
+              throw new NoAuthorizationInCookieError()
+            }
+            token = value
+          } else {
+            token = tokenValue
+          }
         } else {
           throw new NoAuthorizationInCookieError()
         }
@@ -483,13 +491,13 @@ function fastifyJwt (fastify, options, next) {
     }
 
     let token
+    let decodedToken
     try {
       token = lookupToken(request, options.verify || options)
+      decodedToken = decode(token, options.decode || decodeOptions)
     } catch (err) {
       return next(err)
     }
-
-    const decodedToken = decode(token, options.decode || decodeOptions)
 
     steed.waterfall([
       function getSecret (callback) {

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1905,6 +1905,40 @@ test('token in a signed cookie, with @fastify/cookie parsing', async function (t
   t.assert.strictEqual(decodedToken.foo, 'bar')
 })
 
+test('invalid signed cookie should return 401, not 500', async function (t) {
+  t.plan(2)
+
+  const fastify = Fastify()
+  fastify.register(jwt, {
+    secret: 'test',
+    cookie: { cookieName: 'jwt', signed: true }
+  })
+  fastify.register(require('@fastify/cookie'), {
+    secret: 'cookieSecret'
+  })
+
+  fastify.get('/verify', function (request, reply) {
+    return request.jwtVerify()
+      .then(function (decodedToken) {
+        return reply.send(decodedToken)
+      })
+      .catch(function (err) {
+        reply.send(err)
+      })
+  })
+
+  const response = await fastify.inject({
+    method: 'get',
+    url: '/verify',
+    cookies: {
+      jwt: 'invalid-signature' // not a valid signed cookie
+    }
+  })
+
+  t.assert.strictEqual(response.statusCode, 401)
+  t.assert.strictEqual(response.json().message, 'No Authorization was found in request.cookies')
+})
+
 test('token in cookie only, when onlyCookie is passed to verifyJWT()', async function (t) {
   t.plan(4)
 


### PR DESCRIPTION

## Summary

Fixes an issue where an invalid signed cookie causes a **500 Internal Server Error** with stack-trace leakage instead of the correct **401 Unauthorized**.

When using signed cookies (`cookie: { signed: true }`), `@fastify/jwt` reads `request.unsignCookie(tokenValue).value` **without checking the `.valid` field**. An invalid cookie signature returns `{ valid: false, value: null }`. The `null` token is passed to `decode()`, where `assert(token)` throws an `AssertionError` that escapes the try/catch boundaray.

## Changes

1. **lookupToken** — validates `unsignCookie` result before reading `.value`; throws a proper `NoAuthorizationInCookieError` (→ 401) if the signature is invalid.
2. **requestVerify** — moves `decode()` inside the existing try/catch so any null-token assertion failure is caught and mapped to the correct error.

## Testing

- All existing tests pass (176 tests, 100% coverage)
- Added a new test: `invalid signed cookie should return 401, not 500`
