### PR TITLE
fix(types): expose namespace decorator types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,25 +18,12 @@ declare module 'fastify' {
   }
 
   interface FastifyReply {
-    jwtSign(payload: fastifyJwt.SignPayloadType, options?: fastifyJwt.FastifyJwtSignOptions): Promise<string>
-    jwtSign(payload: fastifyJwt.SignPayloadType, callback: SignerCallback): void
-    jwtSign(payload: fastifyJwt.SignPayloadType, options: fastifyJwt.FastifyJwtSignOptions, callback: SignerCallback): void
-    jwtSign(payload: fastifyJwt.SignPayloadType, options?: Partial<fastifyJwt.SignOptions>): Promise<string>
-    jwtSign(payload: fastifyJwt.SignPayloadType, options: Partial<fastifyJwt.SignOptions>, callback: SignerCallback): void
+    jwtSign: fastifyJwt.JwtSignFunction
   }
 
   interface FastifyRequest {
-    jwtVerify<Decoded extends fastifyJwt.VerifyPayloadType>(options?: fastifyJwt.FastifyJwtVerifyOptions): Promise<Decoded>
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    jwtVerify<Decoded extends fastifyJwt.VerifyPayloadType>(callback: VerifierCallback): void
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    jwtVerify<Decoded extends fastifyJwt.VerifyPayloadType>(options: fastifyJwt.FastifyJwtVerifyOptions, callback: VerifierCallback): void
-    jwtVerify<Decoded extends fastifyJwt.VerifyPayloadType>(options?: Partial<fastifyJwt.VerifyOptions>): Promise<Decoded>
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    jwtVerify<Decoded extends fastifyJwt.VerifyPayloadType>(options: Partial<fastifyJwt.VerifyOptions>, callback: VerifierCallback): void
-    jwtDecode<Decoded extends fastifyJwt.DecodePayloadType>(options?: fastifyJwt.FastifyJwtDecodeOptions): Promise<Decoded>
-    jwtDecode<Decoded extends fastifyJwt.DecodePayloadType>(callback: fastifyJwt.DecodeCallback<Decoded>): void
-    jwtDecode<Decoded extends fastifyJwt.DecodePayloadType>(options: fastifyJwt.FastifyJwtDecodeOptions, callback: fastifyJwt.DecodeCallback<Decoded>): void
+    jwtVerify: fastifyJwt.JwtVerifyFunction
+    jwtDecode: fastifyJwt.JwtDecodeFunction
     user: fastifyJwt.UserType
   }
 }
@@ -44,6 +31,31 @@ declare module 'fastify' {
 type FastifyJwt = FastifyPluginCallback<fastifyJwt.FastifyJWTOptions>
 
 declare namespace fastifyJwt {
+
+  export interface JwtSignFunction {
+    (payload: SignPayloadType, options?: FastifyJwtSignOptions): Promise<string>
+    (payload: SignPayloadType, callback: SignerCallback): void
+    (payload: SignPayloadType, options: FastifyJwtSignOptions, callback: SignerCallback): void
+    (payload: SignPayloadType, options?: Partial<SignOptions>): Promise<string>
+    (payload: SignPayloadType, options: Partial<SignOptions>, callback: SignerCallback): void
+  }
+
+  export interface JwtVerifyFunction {
+    <Decoded extends VerifyPayloadType>(options?: FastifyJwtVerifyOptions): Promise<Decoded>
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    <Decoded extends VerifyPayloadType>(callback: VerifierCallback): void
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    <Decoded extends VerifyPayloadType>(options: FastifyJwtVerifyOptions, callback: VerifierCallback): void
+    <Decoded extends VerifyPayloadType>(options?: Partial<VerifyOptions>): Promise<Decoded>
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    <Decoded extends VerifyPayloadType>(options: Partial<VerifyOptions>, callback: VerifierCallback): void
+  }
+
+  export interface JwtDecodeFunction {
+    <Decoded extends DecodePayloadType>(options?: FastifyJwtDecodeOptions): Promise<Decoded>
+    <Decoded extends DecodePayloadType>(callback: DecodeCallback<Decoded>): void
+    <Decoded extends DecodePayloadType>(options: FastifyJwtDecodeOptions, callback: DecodeCallback<Decoded>): void
+  }
 
   export type FastifyJwtNamespace<C extends {
     namespace?: string;
@@ -56,21 +68,21 @@ declare namespace fastifyJwt {
     : C extends { namespace: string }
       ? `${C['namespace']}JwtDecode`
       : never,
-  JWT['decode']>
+  JwtDecodeFunction>
   &
   Record<C extends { jwtSign: string }
     ? C['jwtSign']
     : C extends { namespace: string }
       ? `${C['namespace']}JwtSign`
       : never,
-  JWT['sign']>
+  JwtSignFunction>
   &
   Record<C extends { jwtVerify: string }
     ? C['jwtVerify']
     : C extends { namespace: string }
       ? `${C['namespace']}JwtVerify`
       : never,
-  JWT['verify']>
+  JwtVerifyFunction>
 
   /**
    * for declaration merging

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -214,7 +214,7 @@ expect<JwtSignFunction>().type.not.toBe<JWT['sign']>()
 expect<JwtVerifyFunction>().type.not.toBe<JWT['verify']>()
 expect<JwtDecodeFunction>().type.not.toBe<JWT['decode']>()
 
-// Issue #348: namespaced sign/verify/decode decorators on the request and
+// Issue #348 (https://github.com/fastify/fastify-jwt/issues/348): namespaced sign/verify/decode decorators on the request and
 // reply objects should be callable just like the default `jwtSign`,
 // `jwtVerify` and `jwtDecode` decorators.
 declare module 'fastify' {

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -1,5 +1,14 @@
 import fastify from 'fastify'
-import fastifyJwt, { FastifyJWTOptions, FastifyJwtNamespace, JWT, SignOptions, VerifyOptions } from '..'
+import fastifyJwt, {
+  FastifyJWTOptions,
+  FastifyJwtNamespace,
+  JwtDecodeFunction,
+  JwtSignFunction,
+  JwtVerifyFunction,
+  JWT,
+  SignOptions,
+  VerifyOptions
+} from '..'
 import { expect } from 'tstyche'
 import fastifyRateLimit from '@fastify/rate-limit'
 
@@ -148,9 +157,9 @@ app.post('/signup', {
 //   }
 // }
 
-expect<FastifyJwtNamespace<{ namespace: 'security' }>['securityJwtDecode']>().type.toBe<JWT['decode']>()
-expect<FastifyJwtNamespace<{ namespace: 'security' }>['securityJwtSign']>().type.toBe<JWT['sign']>()
-expect<FastifyJwtNamespace<{ namespace: 'security' }>['securityJwtVerify']>().type.toBe<JWT['verify']>()
+expect<FastifyJwtNamespace<{ namespace: 'security' }>['securityJwtDecode']>().type.toBe<JwtDecodeFunction>()
+expect<FastifyJwtNamespace<{ namespace: 'security' }>['securityJwtSign']>().type.toBe<JwtSignFunction>()
+expect<FastifyJwtNamespace<{ namespace: 'security' }>['securityJwtVerify']>().type.toBe<JwtVerifyFunction>()
 
 declare module 'fastify' {
   interface FastifyInstance extends FastifyJwtNamespace<{ namespace: 'tsdTest' }> {
@@ -159,43 +168,85 @@ declare module 'fastify' {
 
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtDecode: 'decode' }>['decode']
->().type.toBe<JWT['decode']>()
+>().type.toBe<JwtDecodeFunction>()
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtDecode: 'decode' }>['securityJwtSign']
->().type.toBe<JWT['sign']>()
+>().type.toBe<JwtSignFunction>()
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtDecode: 'decode' }>['securityJwtVerify']
->().type.toBe<JWT['verify']>()
+>().type.toBe<JwtVerifyFunction>()
 
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtSign: 'decode' }>['securityJwtDecode']
->().type.toBe<JWT['decode']>()
+>().type.toBe<JwtDecodeFunction>()
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtSign: 'sign' }>['sign']
->().type.toBe<JWT['sign']>()
+>().type.toBe<JwtSignFunction>()
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtSign: 'decode' }>['securityJwtVerify']
->().type.toBe<JWT['verify']>()
+>().type.toBe<JwtVerifyFunction>()
 
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtVerify: 'verify' }>['securityJwtDecode']
->().type.toBe<JWT['decode']>()
+>().type.toBe<JwtDecodeFunction>()
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtVerify: 'verify' }>['securityJwtSign']
->().type.toBe<JWT['sign']>()
+>().type.toBe<JwtSignFunction>()
 expect<
   FastifyJwtNamespace<{ namespace: 'security', jwtVerify: 'verify' }>['verify']
->().type.toBe<JWT['verify']>()
+>().type.toBe<JwtVerifyFunction>()
 
 expect<
   FastifyJwtNamespace<{ jwtDecode: 'decode' }>['decode']
->().type.toBe<JWT['decode']>()
+>().type.toBe<JwtDecodeFunction>()
 expect<
   FastifyJwtNamespace<{ jwtSign: 'sign' }>['sign']
->().type.toBe<JWT['sign']>()
+>().type.toBe<JwtSignFunction>()
 expect<
   FastifyJwtNamespace<{ jwtVerify: 'verify' }>['verify']
->().type.toBe<JWT['verify']>()
+>().type.toBe<JwtVerifyFunction>()
+
+// Verify that JWT instance methods are still distinct from request/reply
+// decorator methods — the JWT instance methods take a token argument and
+// are synchronous, while the request/reply decorators infer the token from
+// the request and are asynchronous.
+expect<JwtSignFunction>().type.not.toBe<JWT['sign']>()
+expect<JwtVerifyFunction>().type.not.toBe<JWT['verify']>()
+expect<JwtDecodeFunction>().type.not.toBe<JWT['decode']>()
+
+// Issue #348: namespaced sign/verify/decode decorators on the request and
+// reply objects should be callable just like the default `jwtSign`,
+// `jwtVerify` and `jwtDecode` decorators.
+declare module 'fastify' {
+  interface FastifyInstance extends FastifyJwtNamespace<{
+    namespace: 'accessToken',
+    jwtDecode: 'accessTokenDecode',
+    jwtSign: 'accessTokenSign',
+    jwtVerify: 'accessTokenVerify'
+  }> {}
+
+  interface FastifyReply {
+    accessTokenSign: JwtSignFunction
+  }
+
+  interface FastifyRequest {
+    accessTokenVerify: JwtVerifyFunction
+    accessTokenDecode: JwtDecodeFunction
+  }
+}
+
+app.addHook('preHandler', async (request, reply) => {
+  // Namespaced sign on reply should accept the same overloads as jwtSign.
+  expect(await reply.accessTokenSign({ user: 'userName' })).type.toBe<string>()
+  expect(await reply.accessTokenSign({ user: 'userName' }, { expiresIn: '1h' })).type.toBe<string>()
+
+  // Namespaced verify/decode on request should resolve to the decoded payload
+  // without requiring a token argument.
+  expect(await request.accessTokenVerify()).type.toBe<object | string>()
+  expect(await request.accessTokenVerify<{ user: string }>()).type.toBe<{ user: string }>()
+  expect(await request.accessTokenDecode()).type.toBe<object | string>()
+  expect(await request.accessTokenDecode<{ user: string }>()).type.toBe<{ user: string }>()
+})
 
 let signOptions: SignOptions = {
   key: 'supersecret',


### PR DESCRIPTION
Refs #348.

## Problem

The `FastifyJwtNamespace<T>` helper currently maps the namespaced
decorators (`<ns>JwtSign`, `<ns>JwtVerify`, `<ns>JwtDecode`) to
`JWT['sign']`, `JWT['verify']` and `JWT['decode']`. Those types describe
the synchronous `fastify.jwt.*` instance methods, which take an explicit
token argument and return a value directly.

The decorators that actually end up on `FastifyRequest`/`FastifyReply`
have different signatures:

- `reply.jwtSign(...)` is asynchronous and returns `Promise<string>`.
- `request.jwtVerify(...)` and `request.jwtDecode(...)` extract the
  token from the request, so they do not take a `token` argument.

As a result, users following the [namespace docs](https://github.com/fastify/fastify-jwt?tab=readme-ov-file#namespace)
either get incorrect IntelliSense or have to hand-roll the augmentation
themselves to call `request.accessTokenVerify()` or
`reply.accessTokenSign(payload)`.

## Fix

- Extract the existing request/reply decorator overloads into reusable
  `JwtSignFunction`, `JwtVerifyFunction` and `JwtDecodeFunction`
  interfaces.
- Use those interfaces for the default `FastifyReply.jwtSign`,
  `FastifyRequest.jwtVerify` and `FastifyRequest.jwtDecode`
  declarations, so there is a single source of truth.
- Map `FastifyJwtNamespace` entries to those interfaces, so consumers
  using the `namespace`/`jwtDecode`/`jwtSign`/`jwtVerify` registration
  options get correctly typed decorators on `FastifyRequest` and
  `FastifyReply`.

This is a types-only change. No runtime code is touched.

## Tests

`types/index.tst.ts`:

- Existing `FastifyJwtNamespace` assertions updated to expect the new
  function types instead of the `JWT` instance method types.
- Added negative assertions confirming the new decorator types are
  intentionally distinct from the `JWT` instance method types.
- Added a small end-to-end example that augments `FastifyInstance`,
  `FastifyRequest` and `FastifyReply` with `accessToken*` decorators
  (the exact scenario from #348) and verifies the decorators are
  callable without a token argument and return the expected payload
  type.

`npm test` passes: 175 unit tests, 100% coverage, 34 type assertions.

## Checklist

- [x] run `npm run test`
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certificate of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of Conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)