### PR TITLE
fix: Update fast-jwt to 6.2.4 to fix CVE-2026-44351

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fastify/error": "^4.2.0",
     "@lukeed/ms": "^2.0.2",
-    "fast-jwt": "^6.2.0",
+    "fast-jwt": "^6.2.4",
     "fastify-plugin": "^5.0.1",
     "steed": "^1.1.3"
   },


### PR DESCRIPTION
fixes CVE-2026-44351 found int fast-jwt 6.2.3 and prior
## Testing
Ran unit tests:
```bash
pass ./types/index.tst.ts

Targets:    1 passed, 1 total
Test files: 1 passed, 1 total
Assertions: 25 passed, 25 total
Duration:   0.9s
```


#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
