### PR TITLE
chore(package.json): fix delvedor's personal url

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jsonwebtoken",
     "fastify"
   ],
-  "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
+  "author": "Tomas Della Vedova - @delvedor (https://delvedor.dev)",
   "contributors": [
     {
       "name": "Matteo Collina",


### PR DESCRIPTION
Old link no longer exists