### PR TITLE
docs: clarify namespaced fastify.jwt utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,11 @@ When you omit the `jwtVerify`, `jwtDecode`, or `jwtSign` options, the default
 function name will be `<namespace>JwtVerify`, `<namespace>JwtDecode` and
 `<namespace>JwtSign` correspondingly.
 
+When `namespace` is used, `fastify.jwt` stores one JWT utility object per
+namespace. For example, `namespace: 'security'` exposes
+`fastify.jwt.security.sign()`, `fastify.jwt.security.verify()`, and
+`fastify.jwt.security.decode()`.
+
 #### Example with namespace
 
 ```js


### PR DESCRIPTION
## Summary

- Clarifies that using `namespace` makes `fastify.jwt` an object keyed by namespace.
- Adds the direct utility access shape, e.g. `fastify.jwt.security.sign()`.

Fixes fastify/fastify-jwt#286.

## Verification

- `npm test`
- `git diff --check`

## Contribution notes

- AI-assisted: yes, Codex helped prepare this documentation change.
- Human reviewed: yes, I reviewed the final diff and test output before opening this PR.
- Duplicate check: issue Development references are empty; related PR search only found closed PR #398 and no open/merged competing PR for this clarification.
