### PR TITLE
fix(types): type fastify.jwt as namespace map when namespaces are declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,18 @@ declare module 'fastify' {
 }
 ```
 
+When registering the plugin with `namespace`, `fastify.jwt` is a namespace → `JWT` map at runtime instead of a single `JWT` instance. Declare the registered namespaces in the `FastifyJWT` interface to type it accordingly:
+
+```typescript
+declare module '@fastify/jwt' {
+  interface FastifyJWT {
+    namespaces: 'security' | 'airDrop'
+  }
+}
+
+// fastify.jwt.security.sign(...) and fastify.jwt.airDrop.sign(...) are now typed
+```
+
 ### `messages`
 For your convenience, you can override the default HTTP response messages sent when an unauthorized or bad request error occurs. You can choose the specific messages to override and the rest will fallback to the default messages. The object must be in the format specified in the example below.
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ import {
 
 declare module 'fastify' {
   interface FastifyInstance {
-    jwt: fastifyJwt.JWT
+    jwt: fastifyJwt.JwtDecorator
   }
 
   interface FastifyReply {
@@ -92,11 +92,37 @@ declare namespace fastifyJwt {
    *   }
    * }
    * ```
+   * @example
+   * ```
+   * // With the `namespace` registration option, `fastify.jwt` is a
+   * // namespace -> JWT map at runtime. Declare the registered
+   * // namespaces to type it accordingly.
+   * declare module '@fastify/jwt' {
+   *   interface FastifyJWT {
+   *     namespaces: 'auth' | 'admin'
+   *   }
+   * }
+   * ```
    */
   export interface FastifyJWT {
     // payload: ...
     // user: ...
+    // namespaces: ...
   }
+
+  /**
+   * Type of the `fastify.jwt` decorator.
+   *
+   * Defaults to {@link JWT}. When namespaces are declared via the
+   * {@link FastifyJWT} declaration-merging interface, it becomes a
+   * namespace -> {@link JWT} map, matching the runtime shape produced
+   * by registering the plugin with the `namespace` option.
+   */
+  export type JwtDecorator = FastifyJWT extends { namespaces: infer Namespaces }
+    ? [Namespaces] extends [string]
+        ? Record<Namespaces, JWT>
+        : JWT
+    : JWT
 
   export type SignPayloadType = FastifyJWT extends { payload: infer T }
     ? T extends string | object | Buffer

--- a/types/namespace.tst.ts
+++ b/types/namespace.tst.ts
@@ -1,0 +1,31 @@
+import fastify from 'fastify'
+import fastifyJwt, { JWT } from '..'
+import { expect } from 'tstyche'
+
+// declare the registered namespaces so `fastify.jwt` is typed
+// as the namespace -> JWT map created at runtime
+declare module '..' {
+  interface FastifyJWT {
+    namespaces: 'auth' | 'admin'
+  }
+}
+
+const app = fastify()
+
+app.register(fastifyJwt, { secret: 'auth-secret', namespace: 'auth' })
+app.register(fastifyJwt, { secret: 'admin-secret', namespace: 'admin' })
+
+expect(app.jwt).type.toBe<Record<'auth' | 'admin', JWT>>()
+expect(app.jwt.auth).type.toBe<JWT>()
+expect(app.jwt.admin).type.toBe<JWT>()
+expect(app.jwt.auth.sign).type.toBe<JWT['sign']>()
+expect(app.jwt.admin.verify).type.toBe<JWT['verify']>()
+expect(app.jwt.admin.decode).type.toBe<JWT['decode']>()
+
+// the single-decorator shape must not leak into namespace mode
+expect(app.jwt).type.not.toHaveProperty('sign')
+expect(app.jwt).type.not.toHaveProperty('verify')
+expect(app.jwt).type.not.toHaveProperty('decode')
+
+// only declared namespaces are available
+expect(app.jwt).type.not.toHaveProperty('other')


### PR DESCRIPTION
Fixes #395 (also addresses the `fastify.jwt` half of #321).

## Problem

When registering the plugin with the `namespace` option, `fastify.jwt` becomes a `{ [namespace]: JWT }` map at runtime (`index.js`), but the type declaration hardcodes `FastifyInstance.jwt` as `JWT`. Because TypeScript declaration merging cannot override a conflicting property type, users have no way to correct this on their side — `app.jwt.myNamespace.sign(...)` always fails to typecheck even though it works at runtime.

## Fix

Types-only, no runtime change. `fastify.jwt` is now typed with a new exported `JwtDecorator` conditional type. It defaults to `JWT`, so existing non-namespace users are completely unaffected. Namespace users declare their registered namespaces through the existing `FastifyJWT` declaration-merging interface (the same mechanism already used for `payload`/`user`):

```typescript
declare module '@fastify/jwt' {
  interface FastifyJWT {
    namespaces: 'auth' | 'admin'
  }
}
// app.jwt.auth.sign(...) / app.jwt.admin.verify(...) now typecheck
```

The conditional uses `[Namespaces] extends [string]` to avoid distributing over the union (`Record<'auth', JWT> | Record<'admin', JWT>` would be wrong).

Note on #397: the registration-scoped types rework will touch `types/index.d.ts` too, but it is blocked on unmerged fastify core work and explicitly keeps namespaced decorators on declaration-merging helpers, so this interim non-breaking fix is complementary rather than competing.

## Tests

New `types/namespace.tst.ts` asserts the map shape (`Record<'auth' | 'admin', JWT>`), per-namespace `JWT` methods, and negatives: the single-decorator members (`sign`/`verify`/`decode`) and undeclared namespaces are not present. tstyche checks test files in isolation, so the augmentation does not affect the existing default-mode assertions in `types/index.tst.ts`.

README: documented the pattern in the Namespace → TypeScript section.

## Checklist

- [x] run `npm run test` — lint clean, 176/176 unit tests (100% coverage), 35/35 type assertions
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message and code follows the Developer's Certificate of Origin and the Code of Conduct
